### PR TITLE
Upgrade C++ sdk to v0.16 and implement MoveThroughJointPositions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vscode/*
-*.csv
+logs
 build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/*
+*.csv
 build

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,19 +46,6 @@ RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-15 \
 
 RUN mkdir -p /root/opt/src
 
-# Install Viam C++ SDK from source frozen at a commit
-ENV PINNED_COMMIT_HASH="5461780d4a6bcab18ed4cba51be1de2feb76dddf"
-RUN cd /root/opt/src && \
-    git clone https://github.com/viamrobotics/viam-cpp-sdk && \
-    cd viam-cpp-sdk && \
-    git checkout ${PINNED_COMMIT_HASH} && \
-    mkdir build && \
-    cd build && \
-    cmake  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON -DCMAKE_INSTALL_PREFIX=/usr/local .. -G Ninja  && \
-    ninja all -j 4 && \
-	ninja install -j 4 && \
-    rm -rf /root/opt/src/viam-cpp-sdk
-
 # Install appimage-builder deps
 RUN apt install -y \
     binutils \
@@ -88,3 +75,15 @@ RUN apt install -y libgtest-dev
 # Install Eigen
 RUN apt install -y libeigen3-dev
 
+# Install Viam C++ SDK from source pinned to version 0.16.0
+ENV PINNED_COMMIT_HASH="7c8487c"
+RUN cd /root/opt/src && \
+    git clone https://github.com/viamrobotics/viam-cpp-sdk && \
+    cd viam-cpp-sdk && \
+    git checkout ${PINNED_COMMIT_HASH} && \
+    mkdir build && \
+    cd build && \
+    cmake  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DVIAMCPPSDK_OFFLINE_PROTO_GENERATION=ON -DCMAKE_INSTALL_PREFIX=/usr/local .. -G Ninja  && \
+    ninja all -j 4 && \
+	ninja install -j 4 && \
+    rm -rf /root/opt/src/viam-cpp-sdk

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 
 SANITIZE ?= OFF
 build/universal-robots: format build
+	mkdir logs && \
 	cd build && \
 	cmake -G Ninja -DENABLE_SANITIZER=$(SANITIZE) .. && \
 	ninja all -j 4

--- a/src/ur5e_arm.cpp
+++ b/src/ur5e_arm.cpp
@@ -207,7 +207,7 @@ void UR5eArm::move(std::vector<Eigen::VectorXd> waypoints) {
         }
         buffer << std::endl;
     }
-    std::ofstream outputFile("/src/waypoints.csv");
+    std::ofstream outputFile(path_offset + WAYPOINTS_LOG);
     outputFile << buffer.str();
     outputFile.close();
 
@@ -317,7 +317,7 @@ void UR5eArm::send_trajectory(const std::vector<vector6d_t>& p_p,
         }
     }
 
-    std::ofstream outputFile("/src/trajectory.csv");
+    std::ofstream outputFile(path_offset + TRAJECTORY_LOG);
     outputFile << buffer.str();
     outputFile.close();
 }

--- a/src/ur5e_arm.hpp
+++ b/src/ur5e_arm.hpp
@@ -27,6 +27,10 @@ const std::string SCRIPT_FILE = "/src/control/external_control.urscript";
 const std::string OUTPUT_RECIPE = "/src/control/rtde_output_recipe.txt";
 const std::string INPUT_RECIPE = "/src/control/rtde_input_recipe.txt";
 
+// locations of log files that will be written
+const std::string TRAJECTORY_LOG = "/logs/trajectory.csv";
+const std::string WAYPOINTS_LOG = "/logs/waypoints.csv";
+
 // TODO: using this is deprecated by the URCL, we could find some way around using it
 const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
 

--- a/src/ur5e_arm.hpp
+++ b/src/ur5e_arm.hpp
@@ -43,12 +43,20 @@ class UR5eArm : public Arm, public Reconfigurable {
     /// @brief Get the joint positions of the arm (in degrees)
     /// @param extra Any additional arguments to the method.
     /// @return a vector of joint positions of the arm in degrees
-    std::vector<double> get_joint_positions(const AttributeMap& extra) override;
+    std::vector<double> get_joint_positions(const ProtoStruct& extra) override;
 
     /// @brief Move to the the specified joint positions (in degrees)
     /// @param positions The joint positions in degrees to move to
     /// @param extra Any additional arguments to the method.
-    void move_to_joint_positions(const std::vector<double>& positions, const AttributeMap& extra) override;
+    void move_to_joint_positions(const std::vector<double>& positions, const ProtoStruct& extra) override;
+
+    /// @brief Move through the specified joint positions (in degrees)
+    /// @param positions The joint positions to move through
+    /// @param options Optional parameters that should be obeyed during the motion
+    /// @param extra Any additional arguments to the method.
+    void move_through_joint_positions(const std::vector<std::vector<double>>& positions,
+                                      const MoveOptions& options,
+                                      const viam::sdk::ProtoStruct& extra) override;
 
     /// @brief Reports if the arm is in motion.
     bool is_moving() override;
@@ -57,28 +65,28 @@ class UR5eArm : public Arm, public Reconfigurable {
     /// @param extra Any additional arguments to the method.
     /// @return A variant of kinematics data, with bytes field containing the raw bytes of the file
     /// and the object's type indicating the file format.
-    KinematicsData get_kinematics(const AttributeMap& extra) override;
+    KinematicsData get_kinematics(const ProtoStruct& extra) override;
 
     /// @brief Stops the Arm.
     /// @param extra Extra arguments to pass to the resource's `stop` method.
-    void stop(const AttributeMap& extra) override;
+    void stop(const ProtoStruct& extra) override;
 
     /// @brief This is being used as a proxy to move_to_joint_positions except with support for
     /// multiple waypoints
     /// @param command Will contain a std::vector<std::vector<double>> called positions that will
     /// contain joint waypoints
-    AttributeMap do_command(const AttributeMap& command) override;
+    ProtoStruct do_command(const ProtoStruct& command) override;
 
     // --------------- UNIMPLEMENTED FUNCTIONS ---------------
-    pose get_end_position(const AttributeMap& extra) override {
+    pose get_end_position(const ProtoStruct& extra) override {
         throw std::runtime_error("get_end_position unimplemented");
     }
 
-    void move_to_position(const pose& pose, const AttributeMap& extra) override {
+    void move_to_position(const pose& pose, const ProtoStruct& extra) override {
         throw std::runtime_error("move_to_position unimplemented");
     }
 
-    std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) {
+    std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) {
         throw std::runtime_error("get_geometries unimplemented");
     }
 


### PR DESCRIPTION
This PR does a number of things
- upgrades the C++ SDK to v0.16
- implements MoveThroughJointPositions
- fixes a latent bug in trajectory smoothing that caused intermittent nonsmooth trajectories due to floating point imprecision
- introduces automatic logging of trajectory and waypoint information to a `.csv` buffer file in a new `logs` directory, for the purpose of easier debugging of trajectories