### PR TITLE
Add a destructor to the universal robots model

### DIFF
--- a/src/ur5e_arm.cpp
+++ b/src/ur5e_arm.cpp
@@ -316,6 +316,16 @@ void UR5eArm::move(std::vector<Eigen::VectorXd> waypoints) {
     mu.unlock();
 }
 
+// Define the destructor
+UR5eArm::~UR5eArm() {
+    // stop the robot
+    stop(ProtoStruct{});
+    // disconnect from the dashboard
+    if (dashboard) {
+        dashboard->disconnect();
+    }
+}
+
 // helper function to send time-indexed position, velocity, acceleration setpoints to the UR driver
 void UR5eArm::send_trajectory(const std::vector<vector6d_t>& p_p,
                               const std::vector<vector6d_t>& p_v,

--- a/src/ur5e_arm.hpp
+++ b/src/ur5e_arm.hpp
@@ -41,6 +41,7 @@ const double TIMESTEP = 0.2;    // seconds
 class UR5eArm : public Arm, public Reconfigurable {
    public:
     UR5eArm(Dependencies deps, const ResourceConfig& cfg);
+    ~UR5eArm() override;    
 
     void reconfigure(const Dependencies& deps, const ResourceConfig& cfg) override;
 

--- a/src/ur5e_arm.hpp
+++ b/src/ur5e_arm.hpp
@@ -41,7 +41,7 @@ const double TIMESTEP = 0.2;    // seconds
 class UR5eArm : public Arm, public Reconfigurable {
    public:
     UR5eArm(Dependencies deps, const ResourceConfig& cfg);
-    ~UR5eArm() override;    
+    ~UR5eArm() override;
 
     void reconfigure(const Dependencies& deps, const ResourceConfig& cfg) override;
 


### PR DESCRIPTION
Adds a destructor that calls the ur5e `dashboard->disconnect` [method](https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/1632f6d2635cb809186939a4e4160f1cb0831937/src/ur/dashboard_client.cpp#L100) from the ur5e library to release the 