### PR TITLE
have trajectories log in absolutes

### DIFF
--- a/src/ur5e_arm.cpp
+++ b/src/ur5e_arm.cpp
@@ -34,8 +34,10 @@ void write_trajectory_to_file(std::string filepath,
     }
     std::ofstream of(filepath);
     of << "t(s),j0,j1,j2,j3,j4,j5,v0,v1,v2,v3,v4,v5\n";
+    float time_traj = 0;
     for (size_t i = 0; i < p_p.size(); i++) {
-        of << time[i];
+        time_traj += time[i];
+        of << time_traj;
         for (size_t j = 0; j < 6; j++) {
             of << "," << p_p[i][j];
         }


### PR DESCRIPTION
example output: 

```
t(s),j0,j1,j2,j3,j4,j5,v0,v1,v2,v3,v4,v5
0.2,-3.14159,3.38137e-06,-1.57079,-1.75053,-0.641269,2.50155,0,-0,0,-0,0,0
0.4,-3.11541,3.37789e-06,-1.57079,-1.75053,-0.641269,2.50155,0.174533,-2.31796e-08,1.15898e-07,-4.23855e-07,0,0
0.6,-3.08051,3.37325e-06,-1.57079,-1.75053,-0.641269,2.50155,0.174533,-2.31796e-08,1.15898e-07,-4.23855e-07,0,0
0.8,-3.0456,3.36862e-06,-1.57079,-1.75053,-0.641269,2.50155,0.174533,-2.31796e-08,1.15898e-07,-4.23855e-07,0,0
...
35.4001,2.99325,2.5666e-06,-1.57079,-1.75054,-0.641269,2.50155,0.174533,-2.31796e-08,1.15898e-07,-4.23855e-07,0,0
35.6001,3.02816,2.56197e-06,-1.57079,-1.75054,-0.641269,2.50155,0.174533,-2.31796e-08,1.15898e-07,-4.23855e-07,0,0
35.8001,3.06306,2.55733e-06,-1.57079,-1.75054,-0.641269,2.50155,0.174533,-2.31796e-08,1.15898e-07,-4.23855e-07,0,0
36.0001,3.09797,2.55269e-06,-1.57079,-1.75054,-0.641269,2.50155,0.174533,-2.31796e-08,1.15898e-07,-4.23855e-07,0,0
36.2001,3.13288,2.54806e-06,-1.57079,-1.75054,-0.641269,2.50155,0.174431,-2.3166e-08,1.1583e-07,-4.23607e-07,0,0
36.3,3.14159,2.5469e-06,-1.57079,-1.75054,-0.641269,2.50155,3.94082e-07,-5.23377e-14,2.61688e-13,-9.57032e-13,0,0
```
the .0001 thing im fine with, just floats being floats. the last timestamp can sometimes print weird, but that might just be because my trajectories are simple