### PR TITLE
Move arm driver state into owned struct instance

### DIFF
--- a/src/ur5e_arm.hpp
+++ b/src/ur5e_arm.hpp
@@ -130,25 +130,29 @@ class UR5eArm : public Arm, public Reconfigurable {
     UR5eArm::UrDriverStatus read_joint_keep_alive(bool log);
 
     // private variables to maintain connection and state
-    std::mutex mu;
-    std::unique_ptr<UrDriver> driver;
-    std::unique_ptr<DashboardClient> dashboard;
-    vector6d_t joint_state, tcp_state;
+    struct state_ {
+        std::mutex mu;
+        std::unique_ptr<UrDriver> driver;
+        std::unique_ptr<DashboardClient> dashboard;
+        vector6d_t joint_state, tcp_state;
 
-    std::atomic<bool> shutdown{false};
-    std::thread keep_alive_thread;
-    std::atomic<bool> keep_alive_thread_alive{false};
+        std::atomic<bool> shutdown{false};
+        std::thread keep_alive_thread;
+        std::atomic<bool> keep_alive_thread_alive{false};
 
-    // specified through APPDIR environment variable
-    std::string appdir;
+        // specified through APPDIR environment variable
+        std::string appdir;
 
-    // variables specified by ResourceConfig and set through reconfigure
-    std::string host;
-    std::atomic<double> speed{0};
-    std::atomic<double> acceleration{0};
-    std::atomic<bool> estop{false};
+        // variables specified by ResourceConfig and set through reconfigure
+        std::string host;
+        std::atomic<double> speed{0};
+        std::atomic<double> acceleration{0};
+        std::atomic<bool> estop{false};
 
-    std::mutex output_csv_dir_path_mu;
-    // specified through VIAM_MODULE_DATA environment variable
-    std::string output_csv_dir_path;
+        std::mutex output_csv_dir_path_mu;
+        // specified through VIAM_MODULE_DATA environment variable
+        std::string output_csv_dir_path;
+    };
+
+    std::unique_ptr<state_> current_state_;
 };


### PR DESCRIPTION
This is a purely mechanical change, but it will allow us to entirely drop (or not have) an internal state for a driver instance.

Cases where this is interesting/desirable:
- After `stop` has completed, all internal state can be dropped by calling `current_state.reset()`.
- `reconfigure` can now start by effecting a `stop`, resulting in a fully empty state, then try and build a new state.
- After a failed `reconfigure`, the driver instance will not have any state.

FYI this was mostly done by Claude, please review accordingly.