### PR TITLE
Use the C++ SDK logging macro for logs

### DIFF
--- a/src/ur5e_arm.hpp
+++ b/src/ur5e_arm.hpp
@@ -6,7 +6,6 @@
 #include <ur_client_library/ur/ur_driver.h>
 
 #include <boost/format.hpp>
-#include <boost/log/trivial.hpp>
 #include <viam/sdk/components/arm.hpp>
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/config/resource.hpp>


### PR DESCRIPTION
I'm not entirely sure why upgrading to the 0.13 C++ SDK made `BOOST_LOG_TRIVIAL` stop working, and I certainly didn't expect that outcome. Anyway, it was easy enough to switch over to `VIAM_SDK_LOG`, which I've hand tested and confirmed restored logging.

I think we are supposed to actually be using `VIAM_RESOURCE_LOG`, but it isn't entirely clear to me how we can do that from here because it presupposes that all logging happens in member functions, and we have logs in free functions.