### PR TITLE
Add kinematics files for ur20

### DIFF
--- a/src/kinematics/ur20.json
+++ b/src/kinematics/ur20.json
@@ -1,0 +1,261 @@
+{
+    "name": "UR20",
+    "kinematic_param_type": "SVA",
+    "links": [
+        {
+            "id": "base_link",
+            "parent": "world",
+            "orientation": {
+                "type": "euler_angles",
+                "value": {
+                    "pitch": 0,
+                    "roll": 0,
+                    "yaw": 3.141592653589793
+                }
+            },
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 236.3
+            }
+        },
+        {
+            "id": "shoulder_link",
+            "parent": "shoulder_pan_joint",
+            "orientation": {
+                "type": "euler_angles",
+                "value": {
+                    "pitch": 0,
+                    "roll": 1.570796327,
+                    "yaw": 0
+                }
+            },
+            "geometry": {
+                "type": "capsule",
+                "r": 122.5,
+                "l": 333,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -100
+                },
+                "orientation": {
+                    "type": "quaternion",
+                    "value": {
+                        "W": 0,
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 1
+                    }
+                }
+            }
+        },
+        {
+            "id": "upper_arm_link",
+            "parent": "shoulder_lift_joint",
+            "translation": {
+                "x": -862,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "type": "capsule",
+                "r": 90,
+                "l": 1032,
+                "translation": {
+                    "x": -421.6,
+                    "y": 0,
+                    "z": 260
+                },
+                "orientation": {
+                    "type": "quaternion",
+                    "value": {
+                        "W": 0.5,
+                        "X": 0.5,
+                        "Y": -0.5,
+                        "Z": -0.5
+                    }
+                }
+            }
+        },
+        {
+            "id": "forearm_link",
+            "parent": "elbow_joint",
+            "translation": {
+                "x": -728.7,
+                "y": 0,
+                "z": 201
+            },
+            "geometry": {
+                "type": "capsule",
+                "r": 75,
+                "l": 858,
+                "translation": {
+                    "x": -360,
+                    "y": 0,
+                    "z": 43
+                },
+                "orientation": {
+                    "type": "quaternion",
+                    "value": {
+                        "W": 0.5,
+                        "X": 0.5,
+                        "Y": -0.5,
+                        "Z": -0.5
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_1_link",
+            "parent": "wrist_1_joint",
+            "translation": {
+                "x": 0,
+                "y": -159.3,
+                "z": 0
+            },
+            "orientation": {
+                "type": "euler_angles",
+                "value": {
+                    "pitch": 0,
+                    "roll": 1.570796327,
+                    "yaw": 0
+                }
+            },
+            "geometry": {
+                "type": "capsule",
+                "r": 48.5,
+                "l": 262,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -77.5
+                }
+            }
+        },
+        {
+            "id": "wrist_2_link",
+            "parent": "wrist_2_joint",
+            "translation": {
+                "x": 0,
+                "y": 154.29999999999998,
+                "z": 0
+            },
+            "orientation": {
+                "type": "euler_angles",
+                "value": {
+                    "pitch": 3.141592653589793,
+                    "roll": 1.570796326589793,
+                    "yaw": 3.141592653589793
+                }
+            },
+            "geometry": {
+                "type": "capsule",
+                "r": 48.5,
+                "l": 260,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -74.89999999999999
+                },
+                "orientation": {
+                    "type": "quaternion",
+                    "value": {
+                        "W": 1,
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_3_link",
+            "parent": "wrist_3_joint",
+            "geometry": {
+                "type": "capsule",
+                "r": 48.5,
+                "l": 204,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -70
+                }
+            }
+        }
+    ],
+    "joints": [
+        {
+            "id": "shoulder_pan_joint",
+            "type": "revolute",
+            "parent": "base_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "shoulder_lift_joint",
+            "type": "revolute",
+            "parent": "shoulder_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "elbow_joint",
+            "type": "revolute",
+            "parent": "upper_arm_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 180,
+            "min": -180
+        },
+        {
+            "id": "wrist_1_joint",
+            "type": "revolute",
+            "parent": "forearm_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_2_joint",
+            "type": "revolute",
+            "parent": "wrist_1_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_3_joint",
+            "type": "revolute",
+            "parent": "wrist_2_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        }
+    ]
+}

--- a/src/kinematics/ur20.urdf
+++ b/src/kinematics/ur20.urdf
@@ -1,0 +1,124 @@
+<?xml version="1.0" ?>
+<robot name="ur20">
+  <link name="world"/>
+
+  <link name="base_link">
+  </link>
+
+  <joint name="base_link-base_link_inertia" type="fixed">
+    <parent link="base_link"/>
+    <child link="base_link_inertia"/>
+    <origin rpy="0 0 3.141592653589793" xyz="0 0 0"/>
+  </joint>
+
+  <link name="base_link_inertia"/>
+    <joint name="shoulder_pan_joint" type="revolute">
+    <parent link="base_link_inertia"/>
+    <child link="shoulder_link"/>
+    <origin rpy="0 0 0" xyz="0 0 0.2363"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="738.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="2.0943951023931953"/>
+    <dynamics damping="0" friction="0"/>
+  </joint>
+
+  <link name="shoulder_link">
+    <collision>
+      <origin rpy="0.0 0.0 3.141592653589793" xyz="0.0 0.0 -0.100"/>
+      <geometry>
+        <box size=".1225 .1225 .333"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="shoulder_lift_joint" type="revolute">
+    <parent link="shoulder_link"/>
+    <child link="upper_arm_link"/>
+    <origin rpy="1.570796327 0 0" xyz="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="738.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="2.0943951023931953"/>
+    <dynamics damping="0" friction="0"/>
+  </joint>
+
+  <link name="upper_arm_link">
+    <collision>
+      <origin rpy="1.5707963267948966 0.0 -1.5707963267948966" xyz="-0.5016 0.0 0.26"/>
+      <geometry>
+        <box size= "0.090 0.090 1.032"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="elbow_joint" type="revolute">
+    <parent link="upper_arm_link"/>
+    <child link="forearm_link"/>
+    <origin rpy="0 0 0" xyz="-0.862 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="433.0" lower="-3.141592653589793" upper="3.141592653589793" velocity="2.6179938779914944"/>
+    <dynamics damping="0" friction="0"/>
+  </joint>
+
+  <link name="forearm_link">
+    <collision>
+      <origin rpy="1.5707963267948966 0.0 -1.5707963267948966" xyz="-0.431 0.0 0.043"/>
+      <geometry>
+        <box size= "0.075 0.075 .858"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="wrist_1_joint" type="revolute">
+    <parent link="forearm_link"/>
+    <child link="wrist_1_link"/>
+    <origin rpy="0 0 0" xyz="-0.7287 0 0.201"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="107.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.6651914291880923"/>
+    <dynamics damping="0" friction="0"/>
+  </joint>
+
+  <link name="wrist_1_link">
+    <collision>
+      <origin rpy="1.5707963267948966 0.0 0.0" xyz="0.0 0.0 -0.0775"/>
+      <geometry>
+        <box size= "0.0485 0.262 .0485"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="wrist_2_joint" type="revolute">
+    <parent link="wrist_1_link"/>
+    <child link="wrist_2_link"/>
+    <origin rpy="1.570796327 0 0" xyz="0 -0.1593 -3.267297616249225e-11"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="107.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.6651914291880923"/>
+    <dynamics damping="0" friction="0"/>
+  </joint>
+
+  <link name="wrist_2_link">
+    <collision>
+      <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 -0.0749"/>
+      <geometry>
+        <box size="0.0485 0.0485 .260"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="wrist_3_joint" type="revolute">
+    <parent link="wrist_2_link"/>
+    <child link="wrist_3_link"/>
+    <origin rpy="1.570796326589793 3.141592653589793 3.141592653589793" xyz="0 0.1543 -3.1647459019915597e-11"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="107.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.6651914291880923"/>
+    <dynamics damping="0" friction="0"/>
+  </joint>
+
+  <link name="wrist_3_link">
+      <origin rpy="1.5707963267948966 0.0 0.0" xyz="0.0 0.0 -0.07"/>
+    <collision>
+      <origin rpy="1.5707963267948966 0.0 0.0" xyz="0.0 0.0 -0.07"/>
+      <geometry>
+        <box size="0.0485 0.204 0.0485 "/>
+      </geometry>
+    </collision>
+  </link>
+
+</robot>


### PR DESCRIPTION
Added the kinematics files into the repo in  `src/kinematics` - we prefer the `ur20.json` file over the `ur20.urdf`, since that allows us to generate capsules for the geometries associated with each link of the arm.

