### PR TITLE
[RSDK-10973] fix trajectory test to use expected time behavior

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(test_write_trajectory_to_file) {
         {7.1, 2, 3, 4, 5, 6},
         {10.1, 2, 3, 4, 5, 6},
     };
-    // the time vector is provided in reltive time
+    // the time vector is provided in relative time
     const std::vector<float> time = {1.2, 0.8, 1, 1};
 
     const auto* const expected =

--- a/test.cpp
+++ b/test.cpp
@@ -58,7 +58,8 @@ BOOST_AUTO_TEST_CASE(test_write_trajectory_to_file) {
         {7.1, 2, 3, 4, 5, 6},
         {10.1, 2, 3, 4, 5, 6},
     };
-    const std::vector<float> time = {1.2, 2, 3, 4};
+    // the time vector is provided in reltive time
+    const std::vector<float> time = {1.2, 0.8, 1, 1};
 
     const auto* const expected =
         "t(s),j0,j1,j2,j3,j4,j5,v0,v1,v2,v3,v4,v5\n"


### PR DESCRIPTION
in a previous pr we updated the trajectory file to store timestamps with an absolute time, rather than the relative time diffs that are sent to the arm. Unfortunately, I did not realize there was a test for this function at the time. 

original pr: https://github.com/viam-modules/universal-robots/pull/34
ticket: https://viam.atlassian.net/browse/RSDK-10973