### PR TITLE
[RSDK-11020] Update llvm tools to 19

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,5 +13,5 @@ MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 SortIncludes: true
 SpaceBeforeAssignmentOperators: true
-Standard: Cpp11
+Standard: c++17
 UseTab: Never

--- a/.clang-format
+++ b/.clang-format
@@ -5,4 +5,13 @@ BasedOnStyle: Google
 BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 140
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+IncludeBlocks: Preserve
 IndentWidth: 4
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+SortIncludes: true
+SpaceBeforeAssignmentOperators: true
+Standard: Cpp11
+UseTab: Never

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,15 @@ RUN apt-get -y --no-install-recommends install \
 
 
 RUN bash -c 'wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -'
-RUN apt-add-repository -y 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-15 main'
-RUN apt-add-repository -y 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-15 main'
+RUN apt-add-repository -y 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main'
 RUN apt-get update
-RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-15 \
-    clang-15 \
-    clang-format-15 \
-    clang-tidy-15
+RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-19 \
+    clang-19 \
+    clang-format-19 \
+    clang-tidy-19 \
+    clangd-19 \
+    clang-tools-19 \
+    lldb-19
 
 RUN mkdir -p /root/opt/src
 
@@ -53,6 +55,7 @@ RUN apt install -y \
     desktop-file-utils \
     fakeroot \
     fuse \
+    jq \
     libgdk-pixbuf2.0-dev \
     patchelf \
     python3-pip python3-setuptools \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: build/universal-robots
 
 # format the source code
 format:
-	ls src/*.*pp main.cpp | xargs clang-format-15 -i --style=file
+	ls src/*.*pp main.cpp test.cpp | xargs clang-format-19 -i --style=file
 
 build:
 	mkdir build

--- a/src/ur_arm.cpp
+++ b/src/ur_arm.cpp
@@ -1,13 +1,15 @@
 #include "ur_arm.hpp"
 
-#include <ur_client_library/ur/dashboard_client.h>
-#include <ur_client_library/ur/ur_driver.h>
-
-#include <boost/format.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 #include <chrono>
 #include <cmath>
 #include <thread>
+
+#include <boost/format.hpp>
+#include <boost/numeric/conversion/cast.hpp>
+
+#include <ur_client_library/ur/dashboard_client.h>
+#include <ur_client_library/ur/ur_driver.h>
+
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/module/module.hpp>
 #include <viam/sdk/module/service.hpp>


### PR DESCRIPTION
On macOS, Xcode latest is LLVM 19 based. Bringing the internal tools in docker up to the same point will make it easier to get consistent formatting and clang-tidy results, whether things are run in the container or natively.

Meanwhile, tighten up the clang-format settings to more closely align with the C++ SDK, to help stop clang-format from regrouping headers in a way I don't like.

Then put the header grouping back the way I like it.

Also start running clang-format on the tests.

Finally, install `jq` in the docker container since it will need a rebuild anyway and I expect we will want jq after #54 since then we can write meaningful queries against the compilation database to pick out the files that really belong under tidy's careful watch.