### PR TITLE
[RSDK-11020] Restore magic add-repository call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get -y --no-install-recommends install \
 
 RUN bash -c 'wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -'
 RUN apt-add-repository -y 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main'
+RUN apt-add-repository -y 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main'
 RUN apt-get update
 RUN apt-get -y --no-install-recommends install -t llvm-toolchain-bookworm-19 \
     clang-19 \


### PR DESCRIPTION
Apparently, the duplicated line was needed: https://unix.stackexchange.com/questions/776941/apt-add-repository-needs-to-run-twice-on-debian-12

