### PR TITLE
disable cancelled errors

### DIFF
--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -755,7 +755,7 @@ void URArm::move_(std::vector<Eigen::VectorXd> waypoints, std::chrono::milliseco
         of.close();
         VIAM_SDK_LOG(info) << "move: end unix_time " << unix_time.count();
 
-        // TODO: renable this once zero velocity errors are resolved
+        // TODO(RSDK-11063): renable this once zero velocity errors are resolved
         // https://viam.atlassian.net/browse/RSDK-11063
         // if (current_state_->trajectory_status.load() == TrajectoryStatus::k_cancelled) {
         //     throw std::runtime_error("arm's current trajectory cancelled by code");


### PR DESCRIPTION
disables the throw that occurs when a trajectory gets cancelled, as certain move calls would trigger this error reliably