### PR TITLE
increase min timestep

### DIFF
--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -37,7 +37,7 @@ constexpr auto k_noop_delay = std::chrono::milliseconds(2);     // 2 millisecond
 constexpr auto k_estop_delay = std::chrono::milliseconds(100);  // 100 millisecond, 10 Hz
 
 constexpr double k_waypoint_equivalancy_epsilon_rad = 1e-4;
-constexpr double k_min_timestep_sec = 1e-4;  // determined experimentally, the arm appears to error when given timesteps ~2e-5 and lower
+constexpr double k_min_timestep_sec = 2e-3;  // matches k_noop_delay
 
 // define callback function to be called by UR client library when program state changes
 void reportRobotProgramState(bool program_running) {


### PR DESCRIPTION
had a trajectory generate with a small timestep that was larger than the min timestep currently configured. increasing k_min_timestep_sec to match k_noop_delay for now, and if the problem persists we should look into a different fix
```
t(s),j0,j1,j2,j3,j4,j5,v0,v1,v2,v3,v4,v5
0.2,-4.18901,-1.22027,1.49574,-3.40271,3.11612e-05,1.55663,0,0,-0,-0,-0,0
0.4,-4.14712,-1.21648,1.48997,-3.41794,2.88976e-05,1.57383,0.418879,0.0378715,-0.0576811,-0.152344,-2.26356e-05,0.172003
0.6,-4.02146,-1.20512,1.47267,-3.46364,2.21069e-05,1.62543,0.837758,0.0757431,-0.115362,-0.304688,-4.52712e-05,0.344005
0.8,-3.83293,-1.18807,1.44671,-3.53221,1.19194e-05,1.70284,0.838036,0.0757682,-0.1154,-0.304789,-4.52863e-05,0.344119
1,-3.70721,-1.17671,1.4294,-3.57793,5.12571e-06,1.75446,0.419157,0.0378967,-0.0577194,-0.152445,-2.26506e-05,0.172117
1.2,-3.66527,-1.17291,1.42362,-3.59319,2.85914e-06,1.77169,0.000278276,2.51594e-05,-3.83195e-05,-0.000101207,-1.50376e-08,0.000114267
1.20013,-3.66527,-1.17291,1.42362,-3.59319,2.85914e-06,1.77169,-8.20397e-17,-7.41734e-18,1.12971e-17,2.98374e-17,4.4333e-21,-3.36876e-17

```