### PR TITLE
[RSDK-11246] use ISO8601 for log names

### DIFF
--- a/src/viam/ur/module/test.cpp
+++ b/src/viam/ur/module/test.cpp
@@ -113,8 +113,6 @@ BOOST_AUTO_TEST_CASE(test_write_trajectory_to_file) {
 
 using namespace std::chrono_literals;
 
-
-
 BOOST_AUTO_TEST_CASE(test_waypoints_filename) {
     const std::string k_path = "/home/user";
     const auto timestamp = unix_time_iso8601();

--- a/src/viam/ur/module/test.cpp
+++ b/src/viam/ur/module/test.cpp
@@ -48,16 +48,15 @@ BOOST_AUTO_TEST_CASE(test_sampling_func) {
         const double test_duration_sec = 0;
         const double test_freq_hz = 0.5;  // 1 sample every 2 seconds
 
-        BOOST_CHECK_THROW(
-            sampling_func(
-                test_samples,
-                test_duration_sec,
-                test_freq_hz,
-                [](const double t, const double step) {
-                    BOOST_FAIL("we should never reach this");
-                    return trajectory_sample_point{{t, 0, 0, 0, 0, 0}, {t * step, 0, 0, 0, 0, 0}, boost::numeric_cast<float>(step)};
-                }),
-            std::invalid_argument);
+        BOOST_CHECK_THROW(sampling_func(test_samples,
+                                        test_duration_sec,
+                                        test_freq_hz,
+                                        [](const double t, const double step) {
+                                            BOOST_FAIL("we should never reach this");
+                                            return trajectory_sample_point{
+                                                {t, 0, 0, 0, 0, 0}, {t * step, 0, 0, 0, 0, 0}, boost::numeric_cast<float>(step)};
+                                        }),
+                          std::invalid_argument);
     }
 }
 

--- a/src/viam/ur/module/test.cpp
+++ b/src/viam/ur/module/test.cpp
@@ -113,9 +113,10 @@ BOOST_AUTO_TEST_CASE(test_write_trajectory_to_file) {
 
 using namespace std::chrono_literals;
 
-constexpr std::string k_path = "/home/user";
+
 
 BOOST_AUTO_TEST_CASE(test_waypoints_filename) {
+    const std::string k_path = "/home/user";
     const auto timestamp = unix_time_iso8601();
     const auto path = k_path + "/" + timestamp + "_waypoints.csv";
 
@@ -124,6 +125,7 @@ BOOST_AUTO_TEST_CASE(test_waypoints_filename) {
 }
 
 BOOST_AUTO_TEST_CASE(test_trajectory_filename) {
+    const std::string k_path = "/home/user";
     const auto timestamp = unix_time_iso8601();
     const auto path = k_path + "/" + timestamp + "_trajectory.csv";
 
@@ -132,6 +134,7 @@ BOOST_AUTO_TEST_CASE(test_trajectory_filename) {
 }
 
 BOOST_AUTO_TEST_CASE(test_arm_joint_positions_filename) {
+    const std::string k_path = "/home/user";
     const auto timestamp = unix_time_iso8601();
     const auto path = k_path + "/" + timestamp + "_arm_joint_positions.csv";
 

--- a/src/viam/ur/module/test.cpp
+++ b/src/viam/ur/module/test.cpp
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_write_trajectory_to_file) {
 
 using namespace std::chrono_literals;
 
-const std::string k_path = "/home/user";
+constexpr std::string k_path = "/home/user";
 
 BOOST_AUTO_TEST_CASE(test_waypoints_filename) {
     const auto timestamp = unix_time_iso8601();

--- a/src/viam/ur/module/test.cpp
+++ b/src/viam/ur/module/test.cpp
@@ -113,19 +113,27 @@ BOOST_AUTO_TEST_CASE(test_write_trajectory_to_file) {
 
 using namespace std::chrono_literals;
 
+const std::string k_path = "/home/user";
+
 BOOST_AUTO_TEST_CASE(test_waypoints_filename) {
-    auto x = waypoints_filename("/home/user", 1747161493357ms);
-    BOOST_CHECK_EQUAL(x, "/home/user/1747161493357_waypoints.csv");
+    auto timestamp = unix_time_iso8601();
+    auto x = waypoints_filename(k_path, timestamp);
+    auto path = k_path + "/" + timestamp + "_waypoints.csv";
+    BOOST_CHECK_EQUAL(x, path);
 }
 
 BOOST_AUTO_TEST_CASE(test_trajectory_filename) {
-    auto x = trajectory_filename("/home/user", 1747161493357ms);
-    BOOST_CHECK_EQUAL(x, "/home/user/1747161493357_trajectory.csv");
+    auto timestamp = unix_time_iso8601();
+    auto x = trajectory_filename(k_path, timestamp);
+    auto path = k_path + "/" + timestamp + "_trajectory.csv";
+    BOOST_CHECK_EQUAL(x, path);
 }
 
 BOOST_AUTO_TEST_CASE(test_arm_joint_positions_filename) {
-    auto x = arm_joint_positions_filename("/home/user", 1747161493357ms);
-    BOOST_CHECK_EQUAL(x, "/home/user/1747161493357_arm_joint_positions.csv");
+    auto timestamp = unix_time_iso8601();
+    auto x = arm_joint_positions_filename(k_path, timestamp);
+    auto path = k_path + "/" + timestamp + "_arm_joint_positions.csv";
+    BOOST_CHECK_EQUAL(x, path);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/viam/ur/module/test.cpp
+++ b/src/viam/ur/module/test.cpp
@@ -48,15 +48,16 @@ BOOST_AUTO_TEST_CASE(test_sampling_func) {
         const double test_duration_sec = 0;
         const double test_freq_hz = 0.5;  // 1 sample every 2 seconds
 
-        BOOST_CHECK_THROW(sampling_func(test_samples,
-                                        test_duration_sec,
-                                        test_freq_hz,
-                                        [](const double t, const double step) {
-                                            BOOST_FAIL("we should never reach this");
-                                            return trajectory_sample_point{
-                                                {t, 0, 0, 0, 0, 0}, {t * step, 0, 0, 0, 0, 0}, boost::numeric_cast<float>(step)};
-                                        }),
-                          std::invalid_argument);
+        BOOST_CHECK_THROW(
+            sampling_func(
+                test_samples,
+                test_duration_sec,
+                test_freq_hz,
+                [](const double t, const double step) {
+                    BOOST_FAIL("we should never reach this");
+                    return trajectory_sample_point{{t, 0, 0, 0, 0, 0}, {t * step, 0, 0, 0, 0, 0}, boost::numeric_cast<float>(step)};
+                }),
+            std::invalid_argument);
     }
 }
 
@@ -116,23 +117,26 @@ using namespace std::chrono_literals;
 const std::string k_path = "/home/user";
 
 BOOST_AUTO_TEST_CASE(test_waypoints_filename) {
-    auto timestamp = unix_time_iso8601();
+    const auto timestamp = unix_time_iso8601();
+    const auto path = k_path + "/" + timestamp + "_waypoints.csv";
+
     auto x = waypoints_filename(k_path, timestamp);
-    auto path = k_path + "/" + timestamp + "_waypoints.csv";
     BOOST_CHECK_EQUAL(x, path);
 }
 
 BOOST_AUTO_TEST_CASE(test_trajectory_filename) {
-    auto timestamp = unix_time_iso8601();
+    const auto timestamp = unix_time_iso8601();
+    const auto path = k_path + "/" + timestamp + "_trajectory.csv";
+
     auto x = trajectory_filename(k_path, timestamp);
-    auto path = k_path + "/" + timestamp + "_trajectory.csv";
     BOOST_CHECK_EQUAL(x, path);
 }
 
 BOOST_AUTO_TEST_CASE(test_arm_joint_positions_filename) {
-    auto timestamp = unix_time_iso8601();
+    const auto timestamp = unix_time_iso8601();
+    const auto path = k_path + "/" + timestamp + "_arm_joint_positions.csv";
+
     auto x = arm_joint_positions_filename(k_path, timestamp);
-    auto path = k_path + "/" + timestamp + "_arm_joint_positions.csv";
     BOOST_CHECK_EQUAL(x, path);
 }
 

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -56,8 +56,6 @@ std::chrono::milliseconds unix_now_ms() {
 }
 
 std::string to_iso_8601(std::chrono::milliseconds time) {
-    using namespace std::literals::chrono_literals;
-
     std::stringstream stream;
     auto tp = std::chrono::time_point<std::chrono::system_clock>{} + time;
     auto tt = std::chrono::system_clock::to_time_t(tp);
@@ -68,6 +66,7 @@ std::string to_iso_8601(std::chrono::milliseconds time) {
 
     auto delta_us = time % 1000000;
     stream << "." << std::fixed << std::setw(6) << std::setfill('0') << delta_us.count() << "Z";
+
     return stream.str();
 }
 

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -57,11 +57,15 @@ std::chrono::milliseconds unix_now_ms() {
 
 std::string to_iso_8601(std::chrono::milliseconds time) {
     std::stringstream stream;
+    struct tm buf;
     auto tp = std::chrono::time_point<std::chrono::system_clock>{} + time;
     auto tt = std::chrono::system_clock::to_time_t(tp);
 
-    struct tm buf;
-    gmtime_r(&tt, &buf);
+    auto ret = gmtime_r(&tt, &buf);
+    if (ret == nullptr) {
+        stream << time.count();
+        return stream.str();
+    }
     stream << std::put_time(&buf, "%FT%T");
 
     auto delta_us = time % 1000000;

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -571,19 +571,19 @@ std::vector<double> URArm::get_joint_positions_(const std::shared_lock<std::shar
     return to_ret;
 }
 
-std::string waypoints_filename(const std::string& path, const std::string unix_time) {
+std::string waypoints_filename(const std::string& path, const std::string& unix_time) {
     constexpr char kWaypointsCsvNameTemplate[] = "/%1%_waypoints.csv";
     auto fmt = boost::format(path + kWaypointsCsvNameTemplate);
     return (fmt % unix_time).str();
 }
 
-std::string trajectory_filename(const std::string& path, const std::string unix_time) {
+std::string trajectory_filename(const std::string& path, const std::string& unix_time) {
     constexpr char kTrajectoryCsvNameTemplate[] = "/%1%_trajectory.csv";
     auto fmt = boost::format(path + kTrajectoryCsvNameTemplate);
     return (fmt % unix_time).str();
 }
 
-std::string arm_joint_positions_filename(const std::string& path, const std::string unix_time) {
+std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time) {
     constexpr char kArmJointPositionsCsvNameTemplate[] = "/%1%_arm_joint_positions.csv";
     auto fmt = boost::format(path + kArmJointPositionsCsvNameTemplate);
     return (fmt % unix_time).str();

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -87,8 +87,7 @@ pose ur_vector_to_pose(urcl::vector6d_t vec) {
     return {position, orientation, theta};
 }
 
-void write_joint_data(
-    const vector6d_t& jp, const vector6d_t& jv, std::ostream& of, const std::string unix_time, std::size_t attempt) {
+void write_joint_data(const vector6d_t& jp, const vector6d_t& jv, std::ostream& of, const std::string unix_time, std::size_t attempt) {
     of << unix_time << "," << attempt << ",";
     for (const double joint_pos : jp) {
         of << joint_pos << ",";
@@ -264,7 +263,7 @@ struct URArm::state_ {
         }
 
         void write_joint_data(vector6d_t& position, vector6d_t& velocity) {
-            ::write_joint_data(position, velocity, arm_joint_positions_stream, unix_now_ms(), arm_joint_positions_sample++);
+            ::write_joint_data(position, velocity, arm_joint_positions_stream, unix_time_iso8601(), arm_joint_positions_sample++);
         }
 
         std::vector<trajectory_sample_point> samples;
@@ -780,9 +779,7 @@ void URArm::keep_alive_() {
     VIAM_SDK_LOG(info) << "keep_alive thread terminating";
 }
 
-void URArm::move_(std::shared_lock<std::shared_mutex> config_rlock,
-                  std::list<Eigen::VectorXd> waypoints,
-                  const std::string unix_time) {
+void URArm::move_(std::shared_lock<std::shared_mutex> config_rlock, std::list<Eigen::VectorXd> waypoints, const std::string unix_time) {
     auto our_config_rlock = std::move(config_rlock);
 
     VIAM_SDK_LOG(info) << "move: start unix_time_ms " << unix_time << " waypoints size " << waypoints.size();

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -604,7 +604,7 @@ std::string unix_time_iso8601() {
         throw std::runtime_error("failed to convert time to iso8601");
     }
     stream << std::put_time(&buf, "%FT%T");
-    stream << "." << std::fixed << std::setw(6) << std::setfill('0') << delta_us.count() << "Z";
+    stream << "." << std::setw(6) << std::setfill('0') << delta_us.count() << "Z";
 
     return stream.str();
 }

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -141,9 +141,7 @@ class URArm final : public Arm, public Reconfigurable {
 
     std::vector<double> get_joint_positions_(const std::shared_lock<std::shared_mutex>&);
 
-    void move_(std::shared_lock<std::shared_mutex> config_rlock,
-               std::list<Eigen::VectorXd> waypoints,
-               std::string unix_time_ms);
+    void move_(std::shared_lock<std::shared_mutex> config_rlock, std::list<Eigen::VectorXd> waypoints, std::string unix_time_ms);
 
     bool send_trajectory_(const std::vector<trajectory_sample_point>& samples);
 

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -47,9 +47,11 @@ void sampling_func(std::vector<trajectory_sample_point>& samples, double duratio
 
 void write_trajectory_to_file(const std::string& filepath, const std::vector<trajectory_sample_point>& samples);
 void write_waypoints_to_csv(const std::string& filepath, const std::list<Eigen::VectorXd>& waypoints);
-std::string waypoints_filename(const std::string& path, std::chrono::milliseconds unix_time_ms);
-std::string trajectory_filename(const std::string& path, std::chrono::milliseconds unix_time_ms);
-std::string arm_joint_positions_filename(const std::string& path, std::chrono::milliseconds unix_time_ms);
+std::string waypoints_filename(const std::string& path, std::string unix_time);
+std::string trajectory_filename(const std::string& path, std::string unix_time);
+std::string arm_joint_positions_filename(const std::string& path, std::string unix_time);
+std::string arm_joint_positions_filename(const std::string& path, std::string unix_time);
+std::string unix_time_iso8601();
 
 class URArm final : public Arm, public Reconfigurable {
    public:
@@ -136,7 +138,7 @@ class URArm final : public Arm, public Reconfigurable {
 
     void keep_alive_();
 
-    void move_(std::list<Eigen::VectorXd> waypoints, std::chrono::milliseconds unix_time_ms);
+    void move_(std::list<Eigen::VectorXd> waypoints, std::string unix_time);
 
     bool send_trajectory_(const std::vector<trajectory_sample_point>& samples);
 

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -49,10 +49,10 @@ void sampling_func(std::vector<trajectory_sample_point>& samples, double duratio
 
 void write_trajectory_to_file(const std::string& filepath, const std::vector<trajectory_sample_point>& samples);
 void write_waypoints_to_csv(const std::string& filepath, const std::list<Eigen::VectorXd>& waypoints);
-std::string waypoints_filename(const std::string& path, std::string unix_time);
-std::string trajectory_filename(const std::string& path, std::string unix_time);
-std::string arm_joint_positions_filename(const std::string& path, std::string unix_time);
-std::string arm_joint_positions_filename(const std::string& path, std::string unix_time);
+std::string waypoints_filename(const std::string& path, const std::string& unix_time);
+std::string trajectory_filename(const std::string& path, const std::string& unix_time);
+std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
+std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
 std::string unix_time_iso8601();
 
 class URArm final : public Arm, public Reconfigurable {

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -52,7 +52,6 @@ void write_waypoints_to_csv(const std::string& filepath, const std::list<Eigen::
 std::string waypoints_filename(const std::string& path, const std::string& unix_time);
 std::string trajectory_filename(const std::string& path, const std::string& unix_time);
 std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
-std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
 std::string unix_time_iso8601();
 
 class URArm final : public Arm, public Reconfigurable {
@@ -141,7 +140,7 @@ class URArm final : public Arm, public Reconfigurable {
 
     std::vector<double> get_joint_positions_(const std::shared_lock<std::shared_mutex>&);
 
-    void move_(std::shared_lock<std::shared_mutex> config_rlock, std::list<Eigen::VectorXd> waypoints, std::string unix_time_ms);
+    void move_(std::shared_lock<std::shared_mutex> config_rlock, std::list<Eigen::VectorXd> waypoints, const std::string& unix_time_ms);
 
     bool send_trajectory_(const std::vector<trajectory_sample_point>& samples);
 


### PR DESCRIPTION
example filenames after change

```sh
2025-07-10T17:13:48.628738Z_arm_joint_positions.csv
2025-07-10T17:13:48.628738Z_trajectory.csv
2025-07-10T17:13:48.628738Z_waypoints.csv
2025-07-10T17:13:50.630518Z_arm_joint_positions.csv
2025-07-10T17:13:50.630518Z_trajectory.csv
2025-07-10T17:13:50.630518Z_waypoints.csv
2025-07-10T17:13:52.632959Z_arm_joint_positions.csv
2025-07-10T17:13:52.632959Z_trajectory.csv
2025-07-10T17:13:52.632959Z_waypoints.csv
2025-07-10T17:13:54.634718Z_arm_joint_positions.csv
2025-07-10T17:13:54.634718Z_trajectory.csv
2025-07-10T17:13:54.634718Z_waypoints.csv
```