### PR TITLE
[RSDK-10956] allow multiple UR arms on the same robot part

### DIFF
--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -457,6 +457,15 @@ void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const De
     ur_cfg.headless_mode = true;
     ur_cfg.socket_reconnect_attempts = 1;
 
+    ur_cfg.reverse_port = reverse_port.fetch_add(4);
+    ur_cfg.script_sender_port = script_sender_port.fetch_add(4);
+    ur_cfg.trajectory_port = script_sender_port.fetch_add(4);
+    ur_cfg.script_command_port = script_command_port.fetch_add(4);
+    VIAM_SDK_LOG(debug) << "using reverse_port " << ur_cfg.reverse_port;
+    VIAM_SDK_LOG(debug) << "using script_sender_port " << ur_cfg.script_sender_port;
+    VIAM_SDK_LOG(debug) << "using trajectory_port " << ur_cfg.trajectory_port;
+    VIAM_SDK_LOG(debug) << "using script_command_port " << ur_cfg.script_command_port;
+
     current_state_->driver.reset(new UrDriver(ur_cfg));
 
     // define callback function to be called by UR client library when trajectory state changes

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -15,6 +15,7 @@
 
 #include <ur_client_library/types.h>
 #include <ur_client_library/ur/dashboard_client.h>
+#include <ur_client_library/ur/ur_driver.h>
 
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/module/module.hpp>
@@ -455,7 +456,14 @@ void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const De
     ur_cfg.handle_program_state = &reportRobotProgramState;
     ur_cfg.headless_mode = true;
     ur_cfg.socket_reconnect_attempts = 1;
-    set_ports(ur_cfg);
+
+    if (!current_ports_) {
+        current_ports_ = new_ports();
+    }
+    ur_cfg.reverse_port = current_ports_->reverse_port;
+    ur_cfg.script_sender_port = current_ports_->script_sender_port;
+    ur_cfg.trajectory_port = current_ports_->trajectory_port;
+    ur_cfg.script_command_port = current_ports_->script_command_port;
 
     current_state_->driver.reset(new UrDriver(ur_cfg));
 

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -15,7 +15,6 @@
 
 #include <ur_client_library/types.h>
 #include <ur_client_library/ur/dashboard_client.h>
-#include <ur_client_library/ur/ur_driver.h>
 
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/module/module.hpp>
@@ -456,15 +455,7 @@ void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const De
     ur_cfg.handle_program_state = &reportRobotProgramState;
     ur_cfg.headless_mode = true;
     ur_cfg.socket_reconnect_attempts = 1;
-
-    ur_cfg.reverse_port = reverse_port.fetch_add(4);
-    ur_cfg.script_sender_port = script_sender_port.fetch_add(4);
-    ur_cfg.trajectory_port = script_sender_port.fetch_add(4);
-    ur_cfg.script_command_port = script_command_port.fetch_add(4);
-    VIAM_SDK_LOG(debug) << "using reverse_port " << ur_cfg.reverse_port;
-    VIAM_SDK_LOG(debug) << "using script_sender_port " << ur_cfg.script_sender_port;
-    VIAM_SDK_LOG(debug) << "using trajectory_port " << ur_cfg.trajectory_port;
-    VIAM_SDK_LOG(debug) << "using script_command_port " << ur_cfg.script_command_port;
+    set_ports(ur_cfg);
 
     current_state_->driver.reset(new UrDriver(ur_cfg));
 

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -464,6 +464,10 @@ void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const De
     ur_cfg.script_sender_port = current_ports_->script_sender_port;
     ur_cfg.trajectory_port = current_ports_->trajectory_port;
     ur_cfg.script_command_port = current_ports_->script_command_port;
+    VIAM_SDK_LOG(debug) << "using reverse_port " << ur_cfg.reverse_port;
+    VIAM_SDK_LOG(debug) << "using script_sender_port " << ur_cfg.script_sender_port;
+    VIAM_SDK_LOG(debug) << "using trajectory_port " << ur_cfg.trajectory_port;
+    VIAM_SDK_LOG(debug) << "using script_command_port " << ur_cfg.script_command_port;
 
     current_state_->driver.reset(new UrDriver(ur_cfg));
 

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -64,9 +64,9 @@ struct ports {
 
 // We need to requisition different ports for each independent URArm instance, otherwise they will all try
 // to use the same ports and only one of them will work.
-inline ports new_ports() {
+inline auto new_ports() {
     static std::atomic<uint32_t> port_counter(50001);
-    const uint32_t reverse_port = port_counter.fetch_add(4);
+    const auto reverse_port = port_counter.fetch_add(4);
     return ports{reverse_port, reverse_port + 1, reverse_port + 2, reverse_port + 3};
 }
 

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -54,6 +54,7 @@ std::string trajectory_filename(const std::string& path, const std::string& unix
 std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
 std::string unix_time_iso8601();
 
+// The ports that are currently in use by the underlying UR driver
 struct ports {
     uint32_t reverse_port;
     uint32_t script_sender_port;
@@ -61,6 +62,8 @@ struct ports {
     uint32_t script_command_port;
 };
 
+// We need to requisition different ports for each independent URArm instance, otherwise they will all try
+// to use the same ports and only one of them will work.
 inline ports new_ports() {
     static std::atomic<uint32_t> port_counter(50001);
     const uint32_t reverse_port = port_counter.fetch_add(4);

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -54,6 +54,11 @@ std::string trajectory_filename(const std::string& path, const std::string& unix
 std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
 std::string unix_time_iso8601();
 
+std::atomic<int> reverse_port(50001);
+std::atomic<int> script_sender_port(50002);
+std::atomic<int> trajectory_port(50003);
+std::atomic<int> script_command_port(50004);
+
 class URArm final : public Arm, public Reconfigurable {
    public:
     /// @brief Returns the common ModelFamily for all implementations

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -4,6 +4,7 @@
 
 #include <ur_client_library/control/trajectory_point_interface.h>
 #include <ur_client_library/types.h>
+#include <ur_client_library/ur/ur_driver.h>
 
 #include <viam/sdk/components/arm.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -54,10 +55,13 @@ std::string trajectory_filename(const std::string& path, const std::string& unix
 std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
 std::string unix_time_iso8601();
 
-std::atomic<uint32_t> reverse_port(50001);
-std::atomic<uint32_t> script_sender_port(50002);
-std::atomic<uint32_t> trajectory_port(50003);
-std::atomic<uint32_t> script_command_port(50004);
+inline void set_ports(UrDriverConfiguration& ur_cfg) {
+    static std::atomic<uint32_t> port_counter(50001);
+    ur_cfg.reverse_port = port_counter.fetch_add(1);
+    ur_cfg.script_sender_port = port_counter.fetch_add(1);
+    ur_cfg.trajectory_port = port_counter.fetch_add(1);
+    ur_cfg.script_command_port = port_counter.fetch_add(1);
+}
 
 class URArm final : public Arm, public Reconfigurable {
    public:

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -54,10 +54,10 @@ std::string trajectory_filename(const std::string& path, const std::string& unix
 std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
 std::string unix_time_iso8601();
 
-std::atomic<int> reverse_port(50001);
-std::atomic<int> script_sender_port(50002);
-std::atomic<int> trajectory_port(50003);
-std::atomic<int> script_command_port(50004);
+std::atomic<uint32_t> reverse_port(50001);
+std::atomic<uint32_t> script_sender_port(50002);
+std::atomic<uint32_t> trajectory_port(50003);
+std::atomic<uint32_t> script_command_port(50004);
 
 class URArm final : public Arm, public Reconfigurable {
    public:

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -4,7 +4,6 @@
 
 #include <ur_client_library/control/trajectory_point_interface.h>
 #include <ur_client_library/types.h>
-#include <ur_client_library/ur/ur_driver.h>
 
 #include <viam/sdk/components/arm.hpp>
 #include <viam/sdk/config/resource.hpp>
@@ -55,12 +54,17 @@ std::string trajectory_filename(const std::string& path, const std::string& unix
 std::string arm_joint_positions_filename(const std::string& path, const std::string& unix_time);
 std::string unix_time_iso8601();
 
-inline void set_ports(UrDriverConfiguration& ur_cfg) {
+struct ports {
+    uint32_t reverse_port;
+    uint32_t script_sender_port;
+    uint32_t trajectory_port;
+    uint32_t script_command_port;
+};
+
+inline ports new_ports() {
     static std::atomic<uint32_t> port_counter(50001);
-    ur_cfg.reverse_port = port_counter.fetch_add(1);
-    ur_cfg.script_sender_port = port_counter.fetch_add(1);
-    ur_cfg.trajectory_port = port_counter.fetch_add(1);
-    ur_cfg.script_command_port = port_counter.fetch_add(1);
+    const uint32_t reverse_port = port_counter.fetch_add(4);
+    return ports{reverse_port, reverse_port + 1, reverse_port + 2, reverse_port + 3};
 }
 
 class URArm final : public Arm, public Reconfigurable {
@@ -165,4 +169,5 @@ class URArm final : public Arm, public Reconfigurable {
 
     std::shared_mutex config_mutex_;
     std::unique_ptr<state_> current_state_;
+    std::optional<ports> current_ports_;
 };


### PR DESCRIPTION
Each instantiated UR driver for a single module needs to be passed different client-side ports. This commit increments atomic integers for each port to fix this.