### PR TITLE
[rsdk-11005] add URArm log callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ add_library(viam-ur)
 target_sources(viam-ur
   PRIVATE
     src/viam/ur/module/ur_arm.cpp
+    src/viam/ur/module/utils.hpp
+
 )
 target_link_libraries(viam-ur
   PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,8 +109,6 @@ add_library(viam-ur)
 target_sources(viam-ur
   PRIVATE
     src/viam/ur/module/ur_arm.cpp
-    src/viam/ur/module/utils.hpp
-
 )
 target_link_libraries(viam-ur
   PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(viam-ur)
 target_sources(viam-ur
   PRIVATE
     src/viam/ur/module/ur_arm.cpp
+    src/viam/ur/module/utils.cpp
 )
 target_link_libraries(viam-ur
   PUBLIC

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -330,6 +330,7 @@ URArm::URArm(Model model, const Dependencies& deps, const ResourceConfig& cfg) :
     VIAM_SDK_LOG(info) << "URArm constructor called (model: " << model_.to_string() << ")";
     const std::unique_lock wlock(config_mutex_);
     configure_(wlock, deps, cfg);
+    configure_logger(cfg);
 }
 
 void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies&, const ResourceConfig& cfg) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -16,7 +16,7 @@
 #include <ur_client_library/types.h>
 #include <ur_client_library/ur/dashboard_client.h>
 #include <ur_client_library/ur/ur_driver.h>
-#include "ur_client_library/log.h"
+#include <ur_client_library/log.h>
 
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/module/module.hpp>

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -1,4 +1,5 @@
 #include "ur_arm.hpp"
+#include "utils.hpp"
 
 #include <chrono>
 #include <cmath>
@@ -24,8 +25,6 @@
 #include <viam/sdk/resource/resource.hpp>
 
 #include <third_party/trajectories/Trajectory.h>
-
-#include "utils.hpp"
 
 // this chunk of code uses the rust FFI to handle the spatialmath calculations to turn a UR vector to a pose
 extern "C" void* quaternion_from_axis_angle(double x, double y, double z, double theta);

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -19,6 +19,7 @@
 #include <ur_client_library/ur/ur_driver.h>
 
 #include <viam/sdk/components/component.hpp>
+#include <viam/sdk/log/logging.hpp>
 #include <viam/sdk/module/module.hpp>
 #include <viam/sdk/module/service.hpp>
 #include <viam/sdk/registry/registry.hpp>
@@ -147,23 +148,26 @@ auto make_scope_guard(Callable&& cleanup) {
 class URArmLogHandler : public urcl::LogHandler {
    public:
     URArmLogHandler() = default;
-
     void log(const char* file, int line, urcl::LogLevel loglevel, const char* log) override {
+        std::ostringstream os;
+        os << "URCL - " << log_detail::trim_filename(file).data() << " " << line << ": " << log;
+        const std::string logMsg = os.str();
+
         switch (loglevel) {
             case urcl::LogLevel::INFO:
-                VIAM_SDK_LOG(info) << "URCL - " << file << " " << line << ": " << log;
+                VIAM_SDK_LOG(info) << logMsg;
                 break;
             case urcl::LogLevel::DEBUG:
-                VIAM_SDK_LOG(debug) << "URCL - " << file << " " << line << ": " << log;
+                VIAM_SDK_LOG(debug) << logMsg;
                 break;
             case urcl::LogLevel::WARN:
-                VIAM_SDK_LOG(warn) << "URCL - " << file << " " << line << ": " << log;
+                VIAM_SDK_LOG(warn) << logMsg;
                 break;
             case urcl::LogLevel::ERROR:
-                VIAM_SDK_LOG(error) << "URCL - " << file << " " << line << ": " << log;
+                VIAM_SDK_LOG(error) << logMsg;
                 break;
             case urcl::LogLevel::FATAL:
-                VIAM_SDK_LOG(error) << "URCL - " << file << " " << line << ": " << log;
+                VIAM_SDK_LOG(error) << logMsg;
                 break;
             default:
                 break;

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -371,8 +371,7 @@ URArm::URArm(Model model, const Dependencies& deps, const ResourceConfig& cfg) :
 
 void URArm::configure_logger_(const urcl::LogLevel level) {
     urcl::setLogLevel(level);
-    std::unique_ptr<URArmLogHandler> log_handler(new URArmLogHandler);
-    urcl::registerLogHandler(std::move(log_handler));
+    urcl::registerLogHandler(std::make_unique<URArmLogHandler>());
 }
 
 void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies&, const ResourceConfig& cfg) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -133,7 +133,6 @@ auto make_scope_guard(Callable&& cleanup) {
     };
     return guard{std::forward<Callable>(cleanup)};
 }
-
 }  // namespace
 
 void write_trajectory_to_file(const std::string& filepath, const std::vector<trajectory_sample_point>& samples) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -330,7 +330,8 @@ URArm::URArm(Model model, const Dependencies& deps, const ResourceConfig& cfg) :
     VIAM_SDK_LOG(info) << "URArm constructor called (model: " << model_.to_string() << ")";
     const std::unique_lock wlock(config_mutex_);
     configure_(wlock, deps, cfg);
-    configure_logger(cfg); // TODO: prevent multiple calls to configure_logger
+    // TODO: prevent multiple calls to configure_logger
+    configure_logger(cfg);
 }
 
 void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies&, const ResourceConfig& cfg) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -200,16 +200,16 @@ class URArmLogHandler : public urcl::LogHandler {
                 VIAM_SDK_LOG(info) << "URCL - " << file << " " << line << ": " << log;
                 break;
             case urcl::LogLevel::DEBUG:
-                VIAM_SDK_LOG(debug) << "URCL - " << file << " " << ": " << log;
+                VIAM_SDK_LOG(debug) << "URCL - " << file << " " << line << ": " << log;
                 break;
             case urcl::LogLevel::WARN:
-                VIAM_SDK_LOG(warn) << "URCL - " << file << " " << ": " << log;
+                VIAM_SDK_LOG(warn) << "URCL - " << file << " " << line << ": " << log;
                 break;
             case urcl::LogLevel::ERROR:
-                VIAM_SDK_LOG(error) << "URCL - " << file << " " << ": " << log;
+                VIAM_SDK_LOG(error) << "URCL - " << file << " " << line << ": " << log;
                 break;
             case urcl::LogLevel::FATAL:
-                VIAM_SDK_LOG(error) << "URCL - " << file << " " << ": " << log;
+                VIAM_SDK_LOG(error) << "URCL - " << file << " " << line << ": " << log;
                 break;
             default:
                 break;

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -330,7 +330,6 @@ URArm::URArm(Model model, const Dependencies& deps, const ResourceConfig& cfg) :
     VIAM_SDK_LOG(info) << "URArm constructor called (model: " << model_.to_string() << ")";
     const std::unique_lock wlock(config_mutex_);
     configure_(wlock, deps, cfg);
-    configure_logger(cfg);
 }
 
 void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies&, const ResourceConfig& cfg) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -13,10 +13,10 @@
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
+#include <ur_client_library/log.h>
 #include <ur_client_library/types.h>
 #include <ur_client_library/ur/dashboard_client.h>
 #include <ur_client_library/ur/ur_driver.h>
-#include <ur_client_library/log.h>
 
 #include <viam/sdk/components/component.hpp>
 #include <viam/sdk/module/module.hpp>

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -330,7 +330,7 @@ URArm::URArm(Model model, const Dependencies& deps, const ResourceConfig& cfg) :
     VIAM_SDK_LOG(info) << "URArm constructor called (model: " << model_.to_string() << ")";
     const std::unique_lock wlock(config_mutex_);
     configure_(wlock, deps, cfg);
-    configure_logger(cfg);
+    configure_logger(cfg); // TODO: prevent multiple calls to configure_logger
 }
 
 void URArm::configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies&, const ResourceConfig& cfg) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -369,7 +369,7 @@ URArm::URArm(Model model, const Dependencies& deps, const ResourceConfig& cfg) :
     configure_logger_(urcl::LogLevel::WARN);
 }
 
-static void URArm::configure_logger_(const urcl::LogLevel level) {
+void URArm::configure_logger_(const urcl::LogLevel level) {
     urcl::setLogLevel(level);
     std::unique_ptr<URArmLogHandler> log_handler(new URArmLogHandler);
     urcl::registerLogHandler(std::move(log_handler));

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -369,7 +369,7 @@ URArm::URArm(Model model, const Dependencies& deps, const ResourceConfig& cfg) :
     configure_logger_(urcl::LogLevel::WARN);
 }
 
-void URArm::configure_logger_(urcl::LogLevel level) {
+static void URArm::configure_logger_(const urcl::LogLevel level) {
     urcl::setLogLevel(level);
     std::unique_ptr<URArmLogHandler> log_handler(new URArmLogHandler);
     urcl::registerLogHandler(std::move(log_handler));

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -131,6 +131,8 @@ class URArm final : public Arm, public Reconfigurable {
 
     void configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies& deps, const ResourceConfig& cfg);
 
+    void configure_logger_(const urcl::LogLevel);
+
     template <template <typename> typename lock_type>
     void check_configured_(const lock_type<std::shared_mutex>&);
 

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -131,7 +131,7 @@ class URArm final : public Arm, public Reconfigurable {
 
     void configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies& deps, const ResourceConfig& cfg);
 
-    void configure_logger_(urcl::LogLevel);
+    static void configure_logger_(urcl::LogLevel);
 
     template <template <typename> typename lock_type>
     void check_configured_(const lock_type<std::shared_mutex>&);

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -131,7 +131,7 @@ class URArm final : public Arm, public Reconfigurable {
 
     void configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies& deps, const ResourceConfig& cfg);
 
-    void configure_logger_(const urcl::LogLevel);
+    void configure_logger_(urcl::LogLevel);
 
     template <template <typename> typename lock_type>
     void check_configured_(const lock_type<std::shared_mutex>&);

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -131,8 +131,6 @@ class URArm final : public Arm, public Reconfigurable {
 
     void configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies& deps, const ResourceConfig& cfg);
 
-    static void configure_logger_(urcl::LogLevel);
-
     template <template <typename> typename lock_type>
     void check_configured_(const lock_type<std::shared_mutex>&);
 

--- a/src/viam/ur/module/utils.cpp
+++ b/src/viam/ur/module/utils.cpp
@@ -10,7 +10,7 @@ void configure_logger(const viam::sdk::ResourceConfig& cfg) {
     try {
         level_str = find_config_attribute<std::string>(cfg, "log_level");
     } catch (...) {
-        level_str = "debug";
+        level_str = "warn";
     }
     const auto level = [&] {
         if (level_str == "info") {

--- a/src/viam/ur/module/utils.cpp
+++ b/src/viam/ur/module/utils.cpp
@@ -12,6 +12,7 @@ void configure_logger(const viam::sdk::ResourceConfig& cfg) {
     } catch (...) {
         level_str = "warn";
     }
+    VIAM_SDK_LOG(debug) << "setting URArm log level to '" << level_str << "'";
     const auto level = [&] {
         if (level_str == "info") {
             return urcl::LogLevel::INFO;

--- a/src/viam/ur/module/utils.cpp
+++ b/src/viam/ur/module/utils.cpp
@@ -24,8 +24,8 @@ void configure_logger(const viam::sdk::ResourceConfig& cfg) {
         } else if (level_str == "fatal") {
             return urcl::LogLevel::FATAL;
         } else {
-            VIAM_SDK_LOG(error) << "invalid log_level: '" << level_str << "' - defaulting to 'debug'";
-            return urcl::LogLevel::DEBUG;
+            VIAM_SDK_LOG(error) << "invalid log_level: '" << level_str << "' - defaulting to 'warn'";
+            return urcl::LogLevel::WARN;
         }
     }();
     urcl::setLogLevel(level);

--- a/src/viam/ur/module/utils.cpp
+++ b/src/viam/ur/module/utils.cpp
@@ -1,0 +1,33 @@
+#include "utils.hpp"
+
+#include <ur_client_library/log.h>
+
+#include <viam/sdk/log/logging.hpp>
+#include <viam/sdk/resource/resource.hpp>
+
+void configure_logger(const viam::sdk::ResourceConfig& cfg) {
+    std::string level_str{};
+    try {
+        level_str = find_config_attribute<std::string>(cfg, "log_level");
+    } catch (...) {
+        level_str = "debug";
+    }
+    const auto level = [&] {
+        if (level_str == "info") {
+            return urcl::LogLevel::INFO;
+        } else if (level_str == "debug") {
+            return urcl::LogLevel::DEBUG;
+        } else if (level_str == "warn") {
+            return urcl::LogLevel::WARN;
+        } else if (level_str == "error") {
+            return urcl::LogLevel::ERROR;
+        } else if (level_str == "fatal") {
+            return urcl::LogLevel::FATAL;
+        } else {
+            VIAM_SDK_LOG(error) << "invalid log_level: '" << level_str << "' - defaulting to 'debug'";
+            return urcl::LogLevel::DEBUG;
+        }
+    }();
+    urcl::setLogLevel(level);
+    urcl::registerLogHandler(std::make_unique<URArmLogHandler>());
+}

--- a/src/viam/ur/module/utils.hpp
+++ b/src/viam/ur/module/utils.hpp
@@ -1,7 +1,8 @@
 #include <ur_client_library/log.h>
 
 #include <viam/sdk/config/resource.hpp>
-#include <viam/sdk/log/logging.hpp>
+
+void configure_logger(const viam::sdk::ResourceConfig& cfg);
 
 // helper function to extract an attribute value from its key within a ResourceConfig
 template <class T>
@@ -49,5 +50,3 @@ class URArmLogHandler : public urcl::LogHandler {
         }
     }
 };
-
-void configure_logger(const viam::sdk::ResourceConfig& cfg);

--- a/src/viam/ur/module/utils.hpp
+++ b/src/viam/ur/module/utils.hpp
@@ -1,6 +1,10 @@
+#pragma once
+
 #include <ur_client_library/log.h>
+#include <sstream>
 
 #include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/log/logging.hpp>
 
 void configure_logger(const viam::sdk::ResourceConfig& cfg);
 

--- a/src/viam/ur/module/utils.hpp
+++ b/src/viam/ur/module/utils.hpp
@@ -50,29 +50,4 @@ class URArmLogHandler : public urcl::LogHandler {
     }
 };
 
-void configure_logger(const viam::sdk::ResourceConfig& cfg) {
-    std::string level_str{};
-    try {
-        level_str = find_config_attribute<std::string>(cfg, "log_level");
-    } catch (...) {
-        level_str = "warn";
-    }
-    const auto level = [&] {
-        if (level_str == "info") {
-            return urcl::LogLevel::INFO;
-        } else if (level_str == "debug") {
-            return urcl::LogLevel::DEBUG;
-        } else if (level_str == "warn") {
-            return urcl::LogLevel::WARN;
-        } else if (level_str == "error") {
-            return urcl::LogLevel::ERROR;
-        } else if (level_str == "fatal") {
-            return urcl::LogLevel::FATAL;
-        } else {
-            VIAM_SDK_LOG(error) << "invalid log_level: '" << level_str << "' - defaulting to 'debug'";
-            return urcl::LogLevel::DEBUG;
-        }
-    }();
-    urcl::setLogLevel(level);
-    urcl::registerLogHandler(std::make_unique<URArmLogHandler>());
-}
+void configure_logger(const viam::sdk::ResourceConfig& cfg);

--- a/src/viam/ur/module/utils.hpp
+++ b/src/viam/ur/module/utils.hpp
@@ -55,7 +55,7 @@ void configure_logger(const ResourceConfig& cfg) {
     try {
         level_str = find_config_attribute<std::string>(cfg, "log_level");
     } catch (...) {
-        level_str = "debug";
+        level_str = "warn";
     }
     const auto level = [&] {
         if (level_str == "info") {

--- a/src/viam/ur/module/utils.hpp
+++ b/src/viam/ur/module/utils.hpp
@@ -25,7 +25,7 @@ class URArmLogHandler : public urcl::LogHandler {
     URArmLogHandler() = default;
     void log(const char* file, int line, urcl::LogLevel loglevel, const char* log) override {
         std::ostringstream os;
-        os << "URCL - " << log_detail::trim_filename(file).data() << " " << line << ": " << log;
+        os << "URCL - " << file << " " << line << ": " << log;
         const std::string logMsg = os.str();
 
         switch (loglevel) {

--- a/src/viam/ur/module/utils.hpp
+++ b/src/viam/ur/module/utils.hpp
@@ -5,7 +5,7 @@
 
 // helper function to extract an attribute value from its key within a ResourceConfig
 template <class T>
-T find_config_attribute(const ResourceConfig& cfg, const std::string& attribute) {
+T find_config_attribute(const viam::sdk::ResourceConfig& cfg, const std::string& attribute) {
     std::ostringstream buffer;
     auto key = cfg.attributes().find(attribute);
     if (key == cfg.attributes().end()) {
@@ -50,7 +50,7 @@ class URArmLogHandler : public urcl::LogHandler {
     }
 };
 
-void configure_logger(const ResourceConfig& cfg) {
+void configure_logger(const viam::sdk::ResourceConfig& cfg) {
     std::string level_str{};
     try {
         level_str = find_config_attribute<std::string>(cfg, "log_level");

--- a/src/viam/ur/module/utils.hpp
+++ b/src/viam/ur/module/utils.hpp
@@ -1,0 +1,78 @@
+#include <ur_client_library/log.h>
+
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/log/logging.hpp>
+
+// helper function to extract an attribute value from its key within a ResourceConfig
+template <class T>
+T find_config_attribute(const ResourceConfig& cfg, const std::string& attribute) {
+    std::ostringstream buffer;
+    auto key = cfg.attributes().find(attribute);
+    if (key == cfg.attributes().end()) {
+        buffer << "required attribute `" << attribute << "` not found in configuration";
+        throw std::invalid_argument(buffer.str());
+    }
+    const auto* const val = key->second.get<T>();
+    if (!val) {
+        buffer << "required non-empty attribute `" << attribute << " could not be decoded";
+        throw std::invalid_argument(buffer.str());
+    }
+    return *val;
+}
+
+class URArmLogHandler : public urcl::LogHandler {
+   public:
+    URArmLogHandler() = default;
+    void log(const char* file, int line, urcl::LogLevel loglevel, const char* log) override {
+        std::ostringstream os;
+        os << "URCL - " << log_detail::trim_filename(file).data() << " " << line << ": " << log;
+        const std::string logMsg = os.str();
+
+        switch (loglevel) {
+            case urcl::LogLevel::INFO:
+                VIAM_SDK_LOG(info) << logMsg;
+                break;
+            case urcl::LogLevel::DEBUG:
+                VIAM_SDK_LOG(debug) << logMsg;
+                break;
+            case urcl::LogLevel::WARN:
+                VIAM_SDK_LOG(warn) << logMsg;
+                break;
+            case urcl::LogLevel::ERROR:
+                VIAM_SDK_LOG(error) << logMsg;
+                break;
+            case urcl::LogLevel::FATAL:
+                VIAM_SDK_LOG(error) << logMsg;
+                break;
+            default:
+                break;
+        }
+    }
+};
+
+void configure_logger(const ResourceConfig& cfg) {
+    std::string level_str{};
+    try {
+        level_str = find_config_attribute<std::string>(cfg, "log_level");
+    } catch (...) {
+        level_str = "debug";
+    }
+    const auto level = [&] {
+        if (level_str == "info") {
+            return urcl::LogLevel::INFO;
+        } else if (level_str == "debug") {
+            return urcl::LogLevel::DEBUG;
+        } else if (level_str == "warn") {
+            return urcl::LogLevel::WARN;
+        } else if (level_str == "error") {
+            return urcl::LogLevel::ERROR;
+        } else if (level_str == "fatal") {
+            return urcl::LogLevel::FATAL;
+        } else {
+            VIAM_SDK_LOG(error) << "invalid log_level: '" << level_str << "' - defaulting to 'debug'";
+            return urcl::LogLevel::DEBUG;
+        }
+    }();
+    urcl::setLogLevel(level);
+    urcl::registerLogHandler(std::make_unique<URArmLogHandler>());
+}


### PR DESCRIPTION
The UR arm has its own logger that prints warning logs and higher to stdout by default, however we won't see them since we are running this as a separate process. These changes register a logger callback to use `VIAM_SDK_LOG()` instead.

example output seen on app (level set to `INFO` for testing)
```sh
7/14/2025, 4:45:53 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/control/reverse_interface.cpp 219: Robot connected to reverse interface. Ready to receive control commands.   log_ts 2025-07-14T16:45:53.806Z

7/14/2025, 4:45:53 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/helpers.cpp 95: SCHED_FIFO OK, priority 99   log_ts 2025-07-14T16:45:53.773Z

7/14/2025, 4:45:53 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/primary/primary_client.cpp 67: Starting primary client pipeline   log_ts 2025-07-14T16:45:53.750Z

7/14/2025, 4:45:52 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/rtde/rtde_client.cpp 291: Setting up RTDE communication with frequency 500.000000   log_ts 2025-07-14T16:45:52.683Z

7/14/2025, 4:45:52 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/rtde/rtde_client.cpp 139: Negotiated RTDE protocol version to 2.   log_ts 2025-07-14T16:45:52.681Z

7/14/2025, 4:45:52 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/helpers.cpp 95: SCHED_FIFO OK, priority 99   log_ts 2025-07-14T16:45:52.675Z

7/14/2025, 4:45:52 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/ur/dashboard_client.cpp 76: Connected: Universal Robots Dashboard Server   log_ts 2025-07-14T16:45:52.643Z

7/14/2025, 4:45:50 PM info Viam C++ SDK     [module/ur_arm.cpp:200] URCL - /host/build/_deps/universal_robots_client_library-src/src/primary/primary_client.cpp 61: Stopping primary client pipeline   log_ts 2025-07-14T16:45:50.888Z
```