### PR TITLE
[RSDK-11307] fix unrecoverable case on reconfigure 

### DIFF
--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -544,7 +544,6 @@ void URArm::trajectory_done_cb_(const control::TrajectoryResult state) {
 
 void URArm::reconfigure(const Dependencies& deps, const ResourceConfig& cfg) {
     const std::unique_lock wlock{config_mutex_};
-    check_configured_(wlock);
     VIAM_SDK_LOG(warn) << "Reconfigure called: shutting down current state";
     shutdown_(wlock);
     VIAM_SDK_LOG(warn) << "Reconfigure called: configuring new state";
@@ -1188,7 +1187,7 @@ URArm::UrDriverStatus URArm::read_joint_keep_alive_inner_(bool log) {
 
     } else {
         // the arm is in a normal state.
-        if (current_state_->estop.load()) {
+        if (current_state_->estop.load() && !current_state_->local_disconnect.load()) {
             // if the arm was previously estopped, attempt to recover from the estop.
             // We should not enter this code without the user interacting with the arm in some way(i.e. resetting the estop)
             try {


### PR DESCRIPTION
On L1176, there is an ordered check that first checks `current_state->local disconnect` before setting the `current_state->estop` to `true`, however, in practice, it's possible for an operator to switch to manual mode *before* releasing the estop. 

This leads to a path on L1190 where we try to recovery from an estop despite being in manual mode.

Additionally, some scenarios lead to `shutdown_` being called, clearing the `current_state`, `URArm::reconfigure`'s call to `check_configured_` will throw an error because `current_state` doesn't exist.

Removing the check makes sense since we should still be able to reconfigure our module even when a device is estopped or in manual mode. There's already a check in `shutdown_` that checks for state anyway.