### PR TITLE
[RSDK-11279] Refactor internal state management and background processing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,14 @@ include(GNUInstallDirs)
 # Obtain dependencies via FetchContent / find_package
 include(FetchContent)
 
+# NOTE: If you change the version below, please also update
+# the file `src/control/external_control.urscript` to match.
+#
+# TODO: We should just pull that file out of the repository.
 FetchContent_Declare(
   Universal_Robots_Client_Library
   GIT_REPOSITORY https://github.com/UniversalRobots/Universal_Robots_Client_Library
-  GIT_TAG        2.1.0
+  GIT_TAG        2.2.0
   GIT_SHALLOW TRUE
   SYSTEM
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ include(FetchContent)
 # NOTE: If you change the version below, please also update
 # the file `src/control/external_control.urscript` to match.
 #
-# TODO: We should just pull that file out of the repository.
+# TODO(RSDK-11618): We should just pull that file out of the repository.
 FetchContent_Declare(
   Universal_Robots_Client_Library
   GIT_REPOSITORY https://github.com/UniversalRobots/Universal_Robots_Client_Library

--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,13 @@ endef
 # Targets for building AppImages
 appimage-arm64: export OUTPUT_NAME = universal-robots
 appimage-arm64: export ARCH = aarch64
-appimage-arm64: format build
+appimage-arm64: format-check build
 	$(call BUILD_APPIMAGE,$(OUTPUT_NAME),$(ARCH))
 	mv ./packaging/appimages/$(OUTPUT_NAME)-*-$(ARCH).AppImage* ./packaging/appimages/deploy/
 
 appimage-amd64: export OUTPUT_NAME = universal-robots
 appimage-amd64: export ARCH = x86_64
-appimage-amd64: format build
+appimage-amd64: format-check build
 	$(call BUILD_APPIMAGE,$(OUTPUT_NAME),$(ARCH))
 	mv ./packaging/appimages/$(OUTPUT_NAME)-*-$(ARCH).AppImage* ./packaging/appimages/deploy/
 

--- a/src/control/external_control.urscript
+++ b/src/control/external_control.urscript
@@ -8,6 +8,8 @@ textmsg("ExternalControl: steptime=", steptime)
 MULT_jointstate = {{JOINT_STATE_REPLACE}}
 MULT_time = {{TIME_REPLACE}}
 
+DEBUG = False
+
 STOPJ_ACCELERATION = 4.0
 
 #Constants
@@ -35,6 +37,8 @@ MOTION_TYPE_MOVEJ = 0
 MOTION_TYPE_MOVEL = 1
 MOTION_TYPE_MOVEP = 2
 MOTION_TYPE_MOVEC = 3
+MOTION_TYPE_OPTIMOVEJ = 4
+MOTION_TYPE_OPTIMOVEL = 5
 MOTION_TYPE_SPLINE = 51
 TRAJECTORY_DATA_DIMENSION = 3 * 6 + 1
 
@@ -551,6 +555,63 @@ thread trajectoryThread():
           clear_remaining_trajectory_points()
           trajectory_result = TRAJECTORY_RESULT_FAILURE
         end
+
+      # OptimoveJ point
+      elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_OPTIMOVEJ:
+        acceleration = raw_point[13] / MULT_jointstate
+        velocity = raw_point[7] / MULT_jointstate
+        {% if ROBOT_SOFTWARE_VERSION >= v5.21.0 %}
+          {% if ROBOT_SOFTWARE_VERSION < v6.0.0 %}
+        optimovej(q, a = acceleration, v = velocity, r = blend_radius)
+          {% elif ROBOT_SOFTWARE_VERSION >= v10.8.0 %}
+        optimovej(q, a = acceleration, v = velocity, r = blend_radius)
+          {% else %}
+        popup("Optimovej is only supported from software 10.8.0 and upwards.", error=True, blocking=False)
+          {% endif %}
+        {% else %}
+        popup("Optimovej is only supported from software 5.21.0 and upwards.", error=True, blocking=False)
+        {% endif %}
+
+        if DEBUG:
+          textmsg(str_cat("optimovej(", str_cat(
+            str_cat("q=", q), str_cat(
+              str_cat(", a=", acceleration), str_cat(
+                str_cat(", v=", velocity), str_cat(
+                  str_cat(", r=", blend_radius), ")"))))))
+        end
+
+        # reset old acceleration
+        spline_qdd = [0, 0, 0, 0, 0, 0]
+        spline_qd = [0, 0, 0, 0, 0, 0]
+
+      # OptimoveL point
+      elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_OPTIMOVEL:
+        acceleration = raw_point[13] / MULT_jointstate
+        velocity = raw_point[7] / MULT_jointstate
+        
+        {% if ROBOT_SOFTWARE_VERSION >= v5.21.0 %}
+          {% if ROBOT_SOFTWARE_VERSION < v6.0.0 %}
+        optimovel(p[q[0], q[1], q[2], q[3], q[4], q[5]], a = acceleration, v = velocity, r = blend_radius)
+          {% elif ROBOT_SOFTWARE_VERSION >= v10.8.0 %}
+        optimovel(p[q[0], q[1], q[2], q[3], q[4], q[5]], a = acceleration, v = velocity, r = blend_radius)
+          {% else %}
+        popup("Optimovel is only supported from software 10.8.0 and upwards.", error=True, blocking=False)
+          {% endif %}
+        {% else %}
+        popup("Optimovel is only supported from software 5.21.0 and upwards.", error=True, blocking=False)
+        {% endif %}
+
+        if DEBUG:
+          textmsg(str_cat("optimovel(", str_cat(
+            str_cat("q=", p[q[0], q[1], q[2], q[3], q[4], q[5]]), str_cat(
+              str_cat(", a=", acceleration), str_cat(
+                str_cat(", v=", velocity), str_cat(
+                  str_cat(", r=", blend_radius), ")"))))))
+        end
+
+        # reset old acceleration
+        spline_qdd = [0, 0, 0, 0, 0, 0]
+        spline_qd = [0, 0, 0, 0, 0, 0]
       end
     else:
       textmsg("Receiving trajectory point failed!")
@@ -806,7 +867,7 @@ while control_mode > MODE_STOPPED:
 end
 
 textmsg("ExternalControl: Stopping communication and control")
-kill thread_move
+join thread_move
 kill thread_trajectory
 kill thread_script_commands
 stopj(STOPJ_ACCELERATION)

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -295,10 +295,12 @@ class URArm::state_ {
         static std::string_view name();
         auto describe() const;
         std::chrono::milliseconds get_timeout() const;
+
         std::optional<event_variant_> upgrade_downgrade(state_& state);
         std::optional<event_variant_> recv_arm_data(state_&);
         std::optional<event_variant_> handle_move_request(state_& state);
         std::optional<event_variant_> send_noop();
+
         state_variant_ handle_event(event_connection_established_ event);
 
         template <typename Event>
@@ -394,13 +396,9 @@ class URArm::state_ {
         std::shared_future<void> cancel();
 
         void complete_success();
-
         void complete_cancelled();
-
         void complete_failure();
-
         void complete_error(std::string_view message);
-
         void cancel_error(std::string_view message);
 
         void write_joint_data(vector6d_t& position, vector6d_t& velocity);

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -388,6 +388,37 @@ class URArm::state_ {
         reason reason_;
     };
 
+    struct event_connection_established_ {
+        static std::string_view name();
+        auto describe() const;
+        std::unique_ptr<arm_connection_> payload;
+    };
+
+    struct event_connection_lost_ {
+        static std::string_view name();
+        auto describe() const;
+    };
+
+    struct event_estop_detected_ {
+        static std::string_view name();
+        auto describe() const;
+    };
+
+    struct event_estop_cleared_ {
+        static std::string_view name();
+        auto describe() const;
+    };
+
+    struct event_local_mode_detected_ {
+        static std::string_view name();
+        auto describe() const;
+    };
+
+    struct event_remote_mode_restored_ {
+        static std::string_view name();
+        auto describe() const;
+    };
+
     // TODO(acm): Tighten up as a class?
     struct move_request {
        public:
@@ -421,90 +452,18 @@ class URArm::state_ {
         std::optional<cancellation_request> cancellation_request;
     };
 
-    struct event_connection_established_ {
-        std::unique_ptr<arm_connection_> payload;
-        static std::string_view name() {
-            using namespace std::literals::string_view_literals;
-            return "connection_established"sv;
-        }
-
-        auto describe() const {
-            return name();
-        }
-    };
-
-    struct event_connection_lost_ {
-        static std::string_view name() {
-            using namespace std::literals::string_view_literals;
-            return "connection_lost"sv;
-        }
-
-        auto describe() const {
-            return name();
-        }
-    };
-
-    struct event_estop_detected_ {
-        static std::string_view name() {
-            using namespace std::literals::string_view_literals;
-            return "estop_detected"sv;
-        }
-
-        auto describe() const {
-            return name();
-        }
-    };
-
-    struct event_estop_cleared_ {
-        static std::string_view name() {
-            using namespace std::literals::string_view_literals;
-            return "estop_cleared"sv;
-        }
-
-        auto describe() const {
-            return name();
-        }
-    };
-
-    struct event_local_mode_detected_ {
-        static std::string_view name() {
-            using namespace std::literals::string_view_literals;
-            return "local_mode_detected"sv;
-        }
-
-        auto describe() const {
-            return name();
-        }
-    };
-
-    struct event_remote_mode_restored_ {
-        static std::string_view name() {
-            using namespace std::literals::string_view_literals;
-            return "remote_mode_restored"sv;
-        }
-
-        auto describe() const {
-            return name();
-        }
-    };
-
     void emit_event_(event_variant_&& event);
 
     template <typename T>
     void emit_event_(T&& event);
 
     std::chrono::milliseconds get_timeout_() const;
-
     void upgrade_downgrade_();
-
     void recv_arm_data_();
-
     void handle_move_request_();
-
     void send_noop_();
 
     void run_();
-
     void trajectory_done_callback_(control::TrajectoryResult trajectory_result);
 
     const std::string configured_model_type_;
@@ -693,6 +652,13 @@ std::optional<std::shared_future<void>> URArm::state_::cancel_move_request() {
 
     return std::make_optional(move_request_->cancel());
 }
+
+// Many of the state machine types get false positive clang-tidy
+// warnings suggesting that they should be made static. They can't
+// really though. Suppress that tidy warning from here until we are
+// done defining the states and events.
+//
+// NOLINTBEGIN(readability-convert-member-functions-to-static)
 
 std::string_view URArm::state_::state_disconnected_::name() {
     using namespace std::literals::string_view_literals;
@@ -1108,6 +1074,62 @@ template <typename Event>
 URArm::state_::state_variant_ URArm::state_::state_independent_::handle_event(Event) {
     return std::move(*this);
 }
+
+std::string_view URArm::state_::event_connection_established_::name() {
+    using namespace std::literals::string_view_literals;
+    return "connection_established"sv;
+}
+
+auto URArm::state_::event_connection_established_::describe() const {
+    return name();
+}
+
+std::string_view URArm::state_::event_connection_lost_::name() {
+    using namespace std::literals::string_view_literals;
+    return "connection_lost"sv;
+}
+
+auto URArm::state_::event_connection_lost_::describe() const {
+    return name();
+}
+
+std::string_view URArm::state_::event_estop_detected_::name() {
+    using namespace std::literals::string_view_literals;
+    return "estop_detected"sv;
+}
+
+auto URArm::state_::event_estop_detected_::describe() const {
+    return name();
+}
+
+std::string_view URArm::state_::event_estop_cleared_::name() {
+    using namespace std::literals::string_view_literals;
+    return "estop_cleared"sv;
+}
+
+auto URArm::state_::event_estop_cleared_::describe() const {
+    return name();
+}
+
+std::string_view URArm::state_::event_local_mode_detected_::name() {
+    using namespace std::literals::string_view_literals;
+    return "local_mode_detected"sv;
+}
+
+auto URArm::state_::event_local_mode_detected_::describe() const {
+    return name();
+}
+
+std::string_view URArm::state_::event_remote_mode_restored_::name() {
+    using namespace std::literals::string_view_literals;
+    return "remote_mode_restored"sv;
+}
+
+auto URArm::state_::event_remote_mode_restored_::describe() const {
+    return name();
+}
+
+// NOLINTEND(readability-convert-member-functions-to-static)
 
 URArm::state_::move_request::move_request(std::vector<trajectory_sample_point>&& samples, std::ofstream arm_joint_positions_stream)
     : samples(std::move(samples)), arm_joint_positions_stream(std::move(arm_joint_positions_stream)) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -291,8 +291,8 @@ class URArm::state_ {
         std::string describe() const;
         std::chrono::milliseconds get_timeout() const;
 
-        std::optional<event_variant_> upgrade_downgrade(state_& state);
         std::optional<event_variant_> recv_arm_data(state_&);
+        std::optional<event_variant_> upgrade_downgrade(state_& state);
         std::optional<event_variant_> handle_move_request(state_& state);
         std::optional<event_variant_> send_noop();
 
@@ -663,7 +663,6 @@ bool URArm::state_::is_moving() const {
 
 std::optional<std::shared_future<void>> URArm::state_::cancel_move_request() {
     const std::lock_guard lock{mutex_};
-
     if (!move_request_) {
         return std::nullopt;
     }
@@ -816,8 +815,6 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::se
 }
 
 std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::recv_arm_data(state_& state) const {
-    // TODO: This needs to happen for disconnected too.
-
     const auto prior_robot_status_bits = std::exchange(arm_conn_->robot_status_bits, std::nullopt);
     const auto prior_safety_status_bits = std::exchange(arm_conn_->safety_status_bits, std::nullopt);
 
@@ -1626,7 +1623,6 @@ bool URArm::is_moving() {
     const std::shared_lock rlock{config_mutex_};
     check_configured_(rlock);
     return current_state_->is_moving();
-    // return current_state_->trajectory_status.load() == TrajectoryStatus::k_running;
 }
 
 URArm::KinematicsData URArm::get_kinematics(const ProtoStruct&) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -878,7 +878,7 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::re
     // For consistency, update cached data only after all getData
     // calls succeed.
     if (data_good) {
-      state.ephemeral_ = {std::move(joint_positions), std::move(joint_velocities), std::move(tcp_state)};
+        state.ephemeral_ = {std::move(joint_positions), std::move(joint_velocities), std::move(tcp_state)};
     }
 
     return std::nullopt;
@@ -1378,7 +1378,7 @@ void URArm::state_::upgrade_downgrade_() {
 }
 
 void URArm::state_::clear_ephemeral_values_() {
-  ephemeral_.reset();
+    ephemeral_.reset();
 }
 
 void URArm::state_::recv_arm_data_() {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -60,14 +60,6 @@ constexpr auto k_disconnect_delay = std::chrono::seconds(1);
 constexpr double k_waypoint_equivalancy_epsilon_rad = 1e-4;
 constexpr double k_min_timestep_sec = 1e-2;  // determined experimentally, the arm appears to error when given timesteps ~2e-5 and lower
 
-// define callback function to be called by UR client library when program state changes
-// TODO(acm): Do this.
-void reportRobotProgramState(bool program_running) {
-    // Print the text in green so we see it better
-    // TODO(RSDK-11048): verify side-effects on logstream, rm direct coloring
-    VIAM_SDK_LOG(info) << "\033[1;32mUR program running: " << std::boolalpha << program_running << "\033[0m";
-}
-
 template <typename T>
 [[nodiscard]] constexpr decltype(auto) degrees_to_radians(T&& degrees) {
     return std::forward<T>(degrees) * (M_PI / 180.0);
@@ -497,7 +489,6 @@ class URArm::state_ {
     struct event_local_mode_detected_ {};
     struct event_remote_mode_restored_ {};
 
-    // TODO: Should this propagate the lock proof? Or are we deep enough in the state machine that it doesn't matter.
     template <typename T>
     void emit_event_(T&& event);
 
@@ -813,7 +804,8 @@ std::optional<URArm::state_::event_variant> URArm::state_::state_disconnected_::
     ur_cfg.script_file = state.app_dir_ + k_script_file;
     ur_cfg.output_recipe_file = state.app_dir_ + k_output_recipe;
     ur_cfg.input_recipe_file = state.app_dir_ + k_input_recipe;
-    ur_cfg.handle_program_state = reportRobotProgramState;
+    // TODO: Are we going to need a way to wait on the programming being running?
+    ur_cfg.handle_program_state = [](bool running) { VIAM_SDK_LOG(info) << "UR program is " << (running ? "running" : "not running"); };
     ur_cfg.headless_mode = true;
     ur_cfg.socket_reconnect_attempts = 1;
 

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -124,9 +124,6 @@ std::vector<std::string> validate_config_(const ResourceConfig& cfg) {
     return {};
 }
 
-// NOLINTNEXTLINE(performance-enum-size)
-enum class TrajectoryStatus { k_running = 1, k_cancelled = 2, k_stopped = 3 };
-
 template <typename Callable>
 auto make_scope_guard(Callable&& cleanup) {
     struct guard {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -1084,6 +1084,8 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_independent_::
     if (local_mode()) {
         // If we aren't connected to the dashboard, try to reconnect, so
         // we can get an honest answer to `commandIsInRemoteControl`.
+        //
+        // TODO: Log this
         if (arm_conn_->dashboard->getState() != urcl::comm::SocketState::Connected) {
             arm_conn_->dashboard->disconnect();
             if (!arm_conn_->dashboard->connect(1)) {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -468,7 +468,7 @@ class URArm::state_ {
     std::atomic<double> acceleration_{0};
 
     // TODO: We need to handle this
-    bool is_sim_{false};
+    // bool is_sim_{false};
 
     mutable std::mutex mutex_;
     state_variant_ current_state_{state_disconnected_{}};

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -827,7 +827,8 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::re
 
     auto data_package = arm_conn_->driver->getDataPackage();
 
-    if (data_package) {
+    if (!data_package) {
+        VIAM_SDK_LOG(error) << "Failed to read a data package from the arm: dropping connection";
         return event_connection_lost_{};
     }
 

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -623,8 +623,8 @@ void URArm::state_::shutdown() {
 }
 
 const std::optional<double>& URArm::state_::get_reject_move_request_threshold_rad() const {
-  // NOTE: It is OK to return this as a reference and without taking the lock, as this field is immutable inside `state_`.
-  return reject_move_request_threshold_rad_;
+    // NOTE: It is OK to return this as a reference and without taking the lock, as this field is immutable inside `state_`.
+    return reject_move_request_threshold_rad_;
 }
 
 vector6d_t URArm::state_::read_joint_positions() const {

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -143,10 +143,6 @@ class URArm final : public Arm, public Reconfigurable {
    private:
     class state_;
 
-    enum class UrDriverStatus : int8_t;  // Only available on 3.10/5.4
-
-    static std::string status_to_string_(UrDriverStatus status);
-
     void configure_(const std::unique_lock<std::shared_mutex>& lock, const Dependencies& deps, const ResourceConfig& cfg);
 
     template <template <typename> typename lock_type>
@@ -154,18 +150,11 @@ class URArm final : public Arm, public Reconfigurable {
 
     void shutdown_(const std::unique_lock<std::shared_mutex>& lock) noexcept;
 
-    void keep_alive_();
-
     std::vector<double> get_joint_positions_(const std::shared_lock<std::shared_mutex>&);
 
     void move_(std::shared_lock<std::shared_mutex> config_rlock, std::list<Eigen::VectorXd> waypoints, const std::string& unix_time_ms);
 
-    bool send_trajectory_(const std::vector<trajectory_sample_point>& samples);
-
     void trajectory_done_cb_(control::TrajectoryResult);
-
-    URArm::UrDriverStatus read_joint_keep_alive_(bool log);
-    URArm::UrDriverStatus read_joint_keep_alive_inner_(bool log);
 
     template <template <typename> typename lock_type>
     void stop_(const lock_type<std::shared_mutex>&);

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -139,6 +139,8 @@ class URArm final : public Arm, public Reconfigurable {
     template <template <typename> typename lock_type>
     void stop_(const lock_type<std::shared_mutex>&);
 
+    const Model model_;
+
     const struct ports_ {
         ports_();
 
@@ -147,8 +149,6 @@ class URArm final : public Arm, public Reconfigurable {
         uint32_t trajectory_port;
         uint32_t script_command_port;
     } ports_;
-
-    const Model model_;
 
     std::shared_mutex config_mutex_;
     std::unique_ptr<state_> current_state_;

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -139,7 +139,7 @@ class URArm final : public Arm, public Reconfigurable {
     }
 
    private:
-    struct state_;
+    class state_;
 
     enum class UrDriverStatus : int8_t;  // Only available on 3.10/5.4
 

--- a/src/viam/ur/module/ur_arm.hpp
+++ b/src/viam/ur/module/ur_arm.hpp
@@ -65,8 +65,10 @@ struct ports {
 // We need to requisition different ports for each independent URArm instance, otherwise they will all try
 // to use the same ports and only one of them will work.
 inline auto new_ports() {
-    static std::atomic<uint32_t> port_counter(50001);
-    const auto reverse_port = port_counter.fetch_add(4);
+    uint32_t reverse_port = 50001;
+    // TODO: Don't ship this way.
+    // static std::atomic<uint32_t> port_counter(50001);
+    // const auto reverse_port = port_counter.fetch_add(4);
     return ports{reverse_port, reverse_port + 1, reverse_port + 2, reverse_port + 3};
 }
 


### PR DESCRIPTION
First, apologies for the length and complexity here. It was hard to do this one incrementally since it was basically a rewrite of the entire "urcl" side of the driver.

Overall, this thing is more or less working, and it is far _far_ easier to understand the behavior of the system due to log messages like `URArm state transition from state independent(local) to state controlled due to event remote_mode_restored`. There are some rough edges around coming out of local mode that I'm working through with @JohnN193, but I don't expect they will challenge the overall architecture. There are also some small TODO items still to fix up, but, again, none of them are sufficient to prevent review from proceeding in parallel.

Other things that are overall missing:
- There are a number of areas that could use additional comments, and I plan to add those. Or have claude do it.
- Potentially, this new architecture is much more testable. However, without mocks for the various urcl components, I'd have no way to push the state machine around.

As usual, I will take a pass and leave PR notes to help guide the review.