### PR TITLE
[RSDK-11626] Allow event handlers to not return a new state

### DIFF
--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -637,8 +637,6 @@ void URArm::state_::shutdown() {
         worker.join();
         VIAM_SDK_LOG(info) << "worker thread terminated";
     }
-
-    emit_event_(event_connection_lost_{});
 }
 
 const std::optional<double>& URArm::state_::get_reject_move_request_threshold_rad() const {


### PR DESCRIPTION
Additionally:
- Use CRTP to provide one fallback event handler that all states can use
- Have the fallback handler log but not return a new state
- Don't spam local mode events when we can't send NOOP