### PR TITLE
[RSDK-11625] No special handling is actually required for simulator interaction

### DIFF
--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -493,9 +493,6 @@ class URArm::state_ {
     std::atomic<double> speed_{0};
     std::atomic<double> acceleration_{0};
 
-    // TODO(RSDK-11625): We need to handle this
-    // bool is_sim_{false};
-
     mutable std::mutex mutex_;
     state_variant_ current_state_{state_disconnected_{}};
     std::thread worker_thread_;


### PR DESCRIPTION
Instead, you need to manually enable remote mode in the simulator under the `settings` menu.

Filed
https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/370 for upstream.