### PR TITLE
allow packet loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,15 @@ This repo is a [module](https://docs.viam.com/registry/#modular-resources) that 
 
 ## Configuration and Usage
 
-Navigate to the [**CONFIGURE** tab](https://docs.viam.com/build/configure/) of your [machine](https://docs.viam.com/fleet/machines/) in [the Viam app](https://app.viam.com/).
-[Add `arm / universal-robots` to your machine](https://docs.viam.com/build/configure/#components).
-
-On the new component panel, copy and paste the following attribute template into your camera’s attributes field, editing the attributes as applicable:
+This model can be used to control a universal robots arm from a machine running a viam-server. We recommend that the machine running the viam-server is using a wired ethernet connection for the best performance of this module. The following attribute template can be used to configure this model:
 
 ```json
 {
-    "host": "10.1.10.84",
-    "speed_degs_per_sec": 60,
-    "acceleration_degs_per_sec2": 8
+    "host": <arm ip address string>,
+    "speed_degs_per_sec": <float>,
+    "acceleration_degs_per_sec2": <float>
 }
 ```
-
-> [!NOTE]
-> For more information, see [Configure a Machine](https://docs.viam.com/manage/configuration/).
 
 ### Attributes
 
@@ -34,25 +28,25 @@ The following attributes are available for `viam:universal-robots` arms:
 | `speed_degs_per_sec` | float | **Required** | Set the maximum desired speed of the arm joints in degrees per second. |
 | `acceleration_degs_per_sec2` | float | **Required** | Set the maximum desired acceleration of the arm joints. |
 | `reject_move_request_threshold_deg` | float | Not Required | Rejects move requests when the difference between the current position and first waypoint is above threshold |
-| `robot_control_freq_hz` | float | Not Required | Sets the processing frequency for communication with the arm in cycles/second. **Default 100 Hz** |
+| `robot_control_freq_hz` | float | Not Required | Sets the processing frequency for communication with the arm in cycles/second. If the machine running this model is using WiFi, we recommend configuring this to a lower frequency, such as 10 Hz. **Default 100 Hz** |
 
 ### Example configuration:
 
-```
+#### using a wired ethernet connection on the same network as the arm
+```json
 {
-    "components": [
-        {
-            "name": "myURArm",
-            "attributes": {
-                "host": "10.1.10.84",
-                "speed_degs_per_sec": 120,
-                "acceleration_degs_per_sec2": 8
-            },
-            "namespace": "rdk",
-            "type": "arm",
-            "model": "viam:arm:universal-robots"
-        }
-    ]
+    "host": "10.1.10.84",
+    "speed_degs_per_sec": 120,
+    "acceleration_degs_per_sec2": 8
+}
+```
+#### using a WiFi connection on the same network as the arm
+```json
+{
+    "host": "10.1.10.84",
+    "speed_degs_per_sec": 120,
+    "acceleration_degs_per_sec2": 8,
+    "robot_control_freq_hz": 10 
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ The following attributes are available for `viam:universal-robots` arms:
 }
 ```
 
+### DoCommand
+
+#### set_acc DoCommand
+
+`set_acc` will update the `acceleration_degs_per_sec2` maximum acceleration for joints, in deg/sec^2. The value will reset back to the configured maximum when the arm is reconfigured. 
+
+```json
+{
+  "set_acc": <float>
+}
+```
+
+#### set_vel DoCommand
+
+`set_vel` will update the `speed_degs_per_sec` maximum speed for joints, in deg/sec. The value will reset back to the configured maximum when the arm is reconfigured. 
+
+```json
+{
+  "set_vel": <float>
+}
+```
+
 ### Interacting with the Arm
 First ensure that your machine is displaying as **Live** on the Viam App. Then you can interact with your Universal Robots arm in a couple ways:
 - To simply view data from and manipulate your arm, use the **CONTROL** tab of the Viam App.

--- a/meta.json
+++ b/meta.json
@@ -7,15 +7,18 @@
   "models": [
     {
       "api": "rdk:component:arm",
-      "model": "viam:universal-robots:ur3e"
+      "model": "viam:universal-robots:ur3e",
+      "markdown_link": "README.md#configuration-and-usage"
     },
     {
       "api": "rdk:component:arm",
-      "model": "viam:universal-robots:ur5e"
+      "model": "viam:universal-robots:ur5e",
+      "markdown_link": "README.md#configuration-and-usage"
     },
     {
       "api": "rdk:component:arm",
-      "model": "viam:universal-robots:ur20"
+      "model": "viam:universal-robots:ur20",
+      "markdown_link": "README.md#configuration-and-usage"
     }
   ],
   "entrypoint": "universal-robots.AppImage"

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -929,8 +929,8 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::re
     auto new_packet = arm_conn_->driver->getDataPackage();
     if (!new_packet) {
         consecutive_missed_packets++;
-        constexpr int k_allowed_packet_loss = 3;  // how many packets we can drop before restarting the connection
-        if (consecutive_missed_packets > k_allowed_packet_loss) {
+        // how many packets we can drop before restarting the connection
+        if (consecutive_missed_packets > 3) {
             VIAM_SDK_LOG(error) << "Failed to read a data package from the arm: dropping connection";
             return event_connection_lost_{};
         }

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -373,10 +373,12 @@ class URArm::state_ {
 
         std::chrono::milliseconds get_timeout() const;
 
-        std::optional<event_variant_> recv_arm_data(state_& state) const;
+        std::optional<event_variant_> recv_arm_data(state_& state);
         std::optional<event_variant_> send_noop() const;
 
         std::unique_ptr<arm_connection_> arm_conn_;
+
+        int consecutive_missed_packets{0};
     };
 
     struct state_controlled_ : public state_event_handler_base_<state_controlled_>, public state_connected_ {
@@ -920,14 +922,22 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::se
     return std::nullopt;
 }
 
-std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::recv_arm_data(state_& state) const {
+std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::recv_arm_data(state_& state) {
     const auto prior_robot_status_bits = std::exchange(arm_conn_->robot_status_bits, std::nullopt);
     const auto prior_safety_status_bits = std::exchange(arm_conn_->safety_status_bits, std::nullopt);
-
-    arm_conn_->data_package = arm_conn_->driver->getDataPackage();
-    if (!arm_conn_->data_package) {
-        VIAM_SDK_LOG(error) << "Failed to read a data package from the arm: dropping connection";
-        return event_connection_lost_{};
+    // arm_conn_->data_package
+    auto new_packet = arm_conn_->driver->getDataPackage();
+    if (!new_packet) {
+        consecutive_missed_packets++;
+        constexpr int k_allowed_packet_loss = 3;  // how many packets we can drop before restarting the connection
+        if (consecutive_missed_packets > k_allowed_packet_loss) {
+            VIAM_SDK_LOG(error) << "Failed to read a data package from the arm: dropping connection";
+            return event_connection_lost_{};
+        }
+        VIAM_SDK_LOG(warn) << "Failed to read a data package from the arm: missed a packet: " << consecutive_missed_packets;
+    } else {
+        arm_conn_->data_package = std::move(new_packet);
+        consecutive_missed_packets = 0;
     }
 
     static const std::string k_robot_status_bits_key = "robot_status_bits";


### PR DESCRIPTION
allows for a hardcoded number of packets to be missed before kicking the arm into the disconnected state. 

additionally documents the use of wifi and adds the markdown link to the meta.json, so the docs will now appear on config cards