### PR TITLE
[RSDK-10874] Support building the universal robots driver outside of an appimage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,13 @@ project(
 option(VIAM_UR_USE_WALL_WERROR "Build with -Wall and -Werror flags" ON)
 
 
+# - `VIAM_UR_DISABLE_APPIMAGE`
+#
+# Configure the build for not producing an AppImage
+#
+option(VIAM_UR_DISABLE_APPIMAGE "Disable AppImage builds" OFF)
+
+
 # If no build type is selected, build optimized but retain debug
 # info. This is probably the right build type for packaging and
 # release.
@@ -52,8 +59,32 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 include(GNUInstallDirs)
 
+# If we aren't doing an app image build, configure runtime paths for relocatable installs
+if (VIAM_UR_DISABLE_APPIMAGE)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH false)
+  set(CMAKE_BUILD_RPATH_USE_ORIGIN true)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+  set(CMAKE_SKIP_BUILD_RPATH false)
 
+  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+  if("${isSystemDir}" STREQUAL "-1")
+    # TODO: Is there a way to do this with generator expressions?
+    file(RELATIVE_PATH BINTOPREFIXRELPATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR} ${CMAKE_INSTALL_PREFIX})
+    file(RELATIVE_PATH PREFIXTOLIBRELPATH ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+
+    if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+      list(PREPEND CMAKE_INSTALL_RPATH "@loader_path/${BINTOPREFIXRELPATH}/${PREFIXTOLIBRELPATH}")
+    else()
+      list(PREPEND CMAKE_INSTALL_RPATH "$ORIGIN/${BINTOPREFIXRELPATH}/${PREFIXTOLIBRELPATH}")
+    endif()
+  endif()
+endif()
+
+
+#
 # Obtain dependencies via FetchContent / find_package
+#
+
 include(FetchContent)
 
 # NOTE: If you change the version below, please also update
@@ -72,9 +103,13 @@ FetchContent_MakeAvailable(Universal_Robots_Client_Library)
 FetchContent_Declare(
   viam-cpp-sdk
   GIT_REPOSITORY https://github.com/viamrobotics/viam-cpp-sdk
-  GIT_TAG releases/v0.13.2 # Keep in sync with Dockerfile
+  GIT_TAG releases/v0.19.0 # Keep in sync with Dockerfile
   GIT_SHALLOW TRUE
   SYSTEM
+  # Without this patch command, using this as a SYSTEM package results
+  # in failed compilation due to the statically included protobuf gens
+  # getting in the wrong order. Just delete them, we don't need them.
+  PATCH_COMMAND find ./src/viam/api -name "*.pb.h" -type f -exec rm {} +
   FIND_PACKAGE_ARGS
 )
 FetchContent_MakeAvailable(viam-cpp-sdk)
@@ -86,15 +121,27 @@ find_package(viam-cpp-sdk 0.13 CONFIG REQUIRED viamsdk)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+# Get boost pulled in
+find_package(Boost CONFIG REQUIRED
+  COMPONENTS
+    headers
+)
 
+
+#
 # Declare targets
+#
+
 add_library(trajectories)
+
 set_target_properties(trajectories PROPERTIES SYSTEM TRUE)
+
 target_sources(trajectories
   PRIVATE
     src/third_party/trajectories/Trajectory.cpp
     src/third_party/trajectories/Path.cpp
 )
+
 target_include_directories(trajectories
   INTERFACE
     src
@@ -104,12 +151,35 @@ target_link_libraries(trajectories
   PUBLIC
     Eigen3::Eigen
 )
+
 install(
   TARGETS
     trajectories
 )
 
+
 add_library(viam-ur)
+
+if (VIAM_UR_DISABLE_APPIMAGE)
+
+  # Compute the relative path from the bindir to the data
+  # directory. This is relocatable such that if we later install to a
+  # different prefix it will still be correct, but we need to use the
+  # full paths to compute it.
+  file(RELATIVE_PATH VIAM_UR_RELPATH_BINDIR_TO_DATADIR ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_DATADIR})
+
+  configure_file(
+      src/viam/ur/module/ur_arm_config.hpp.in
+      ${CMAKE_CURRENT_BINARY_DIR}/src/viam/ur/module/ur_arm_config.hpp
+      @ONLY
+  )
+
+  target_include_directories(viam-ur
+    PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/src/viam/ur/module
+  )
+endif()
+
 target_sources(viam-ur
   PRIVATE
     src/viam/ur/module/ur_arm.cpp
@@ -121,12 +191,20 @@ target_sources(viam-ur
     src/viam/ur/module/ur_arm_state_independent.cpp
     src/viam/ur/module/utils.cpp
 )
+
+# Tell boost::dll to use std::filesystem rather than boost::filesystem.
+target_compile_definitions(viam-ur
+  PRIVATE
+    BOOST_DLL_USE_STD_FS
+)
+
 target_link_libraries(viam-ur
   PUBLIC
     trajectories
     urcl
     viam-cpp-sdk::viamsdk
 )
+
 install(
   TARGETS
     viam-ur
@@ -136,6 +214,7 @@ install(
 if (VIAM_UR_USE_WALL_WERROR)
   set(GNULIKE_COMPILERS "Clang" "AppleClang" "GNU")
   if (CMAKE_CXX_COMPILER_ID IN_LIST GNULIKE_COMPILERS)
+    # TODO: Arguably, these should be `PRIVATE`.
     target_compile_options(viam-ur PUBLIC
       -Wall
       -Werror
@@ -158,25 +237,55 @@ endif()
 
 
 add_executable(universal-robots)
+
 target_sources(universal-robots
   PRIVATE
     src/viam/ur/module/main.cpp
 )
+
 target_link_libraries(universal-robots
   PRIVATE
     viam-ur
 )
+
 install(
   TARGETS
     universal-robots
 )
 
+
 add_executable(universal-robots-test)
+
 target_sources(universal-robots-test
   PRIVATE
     src/viam/ur/module/test.cpp
 )
+
 target_link_libraries(universal-robots-test
   PRIVATE
     viam-ur
 )
+
+
+
+#
+# Installation and packaging
+#
+
+if (VIAM_UR_DISABLE_APPIMAGE)
+  configure_file(
+      meta.json-no-app-image.in
+      ${CMAKE_CURRENT_BINARY_DIR}/meta.json
+      @ONLY
+  )
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/meta.json
+    DESTINATION .
+  )
+
+  install(
+    DIRECTORY src/kinematics src/control
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/universal-robots
+  )
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN apt install -y libeigen3-dev
 RUN cd /root/opt/src && \
     git clone https://github.com/viamrobotics/viam-cpp-sdk && \
     cd viam-cpp-sdk && \
-    git checkout releases/v0.16.0 && \
+    git checkout releases/v0.19.0 && \
     cmake -S . -B build \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON \

--- a/meta.json-no-app-image.in
+++ b/meta.json-no-app-image.in
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://dl.viam.dev/module.schema.json",
+  "module_id": "viam:universal-robots",
+  "visibility": "public",
+  "url": "https://github.com/viam-modules/universal-robots",
+  "description": "C++ module for Universal Robots arms",
+  "models": [
+    {
+      "api": "rdk:component:arm",
+      "model": "viam:universal-robots:ur3e",
+      "markdown_link": "README.md#configuration-and-usage"
+    },
+    {
+      "api": "rdk:component:arm",
+      "model": "viam:universal-robots:ur5e",
+      "markdown_link": "README.md#configuration-and-usage"
+    },
+    {
+      "api": "rdk:component:arm",
+      "model": "viam:universal-robots:ur20",
+      "markdown_link": "README.md#configuration-and-usage"
+    }
+  ],
+  "entrypoint": "@CMAKE_INSTALL_BINDIR@/universal-robots"
+}

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -381,9 +381,8 @@ URArm::KinematicsData URArm::get_kinematics(const ProtoStruct&) {
         throw std::runtime_error(str(boost::format("no kinematics file known for model '%1'") % model_.to_string()));
     }();
 
-    constexpr char kSvaFileTemplate[] = "%1%/src/kinematics/%2%.json";
-
-    const auto sva_file_path = str(boost::format(kSvaFileTemplate) % current_state_->app_dir() % model_string);
+    constexpr char kSvaFileTemplate[] = "kinematics/%2%.json";
+    const auto sva_file_path = current_state_->resource_root() / str(boost::format(kSvaFileTemplate) % model_string);
 
     // Open the file in binary mode
     std::ifstream sva_file(sva_file_path, std::ios::binary);

--- a/src/viam/ur/module/ur_arm_config.hpp.in
+++ b/src/viam/ur/module/ur_arm_config.hpp.in
@@ -1,0 +1,4 @@
+#pragma once
+
+/// The relative path that will take us from CMAKE_INSTALL_BINDIR to the root of the configured CMAKE_INSTALL_PREFIX.
+constexpr char k_relpath_bindir_to_datadir[] = "@VIAM_UR_RELPATH_BINDIR_TO_DATADIR@";

--- a/src/viam/ur/module/ur_arm_state.cpp
+++ b/src/viam/ur/module/ur_arm_state.cpp
@@ -17,6 +17,8 @@
 
 #include "ur_arm_config.hpp"
 
+namespace {
+
 std::filesystem::path find_resource_root() {
     const auto module_executable_path = boost::dll::program_location();
     const auto module_executable_directory = module_executable_path.parent_path();
@@ -26,7 +28,11 @@ std::filesystem::path find_resource_root() {
     return data_directory;
 }
 
+}  // namespace
+
 #else
+
+namespace {
 
 std::filesystem::path find_resource_root() {
     // get the APPDIR environment variable
@@ -38,6 +44,8 @@ std::filesystem::path find_resource_root() {
     VIAM_SDK_LOG(info) << "APPDIR is `" << app_dir << "`; resources will be found in `" << data_directory << "`";
     return data_directory;
 }
+
+}  // namespace
 
 #endif
 

--- a/src/viam/ur/module/ur_arm_state.cpp
+++ b/src/viam/ur/module/ur_arm_state.cpp
@@ -1,9 +1,45 @@
 #include "ur_arm_state.hpp"
 
+#include <filesystem>
+#include <stdexcept>
+
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/median.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
+#include <boost/dll/runtime_symbol_info.hpp>
+
+// The `ur_arm_config.hpp` header is only generated for non-AppImage
+// builds. If the header exists, include it and note that we aren't
+// using appimage. Otherwise, we are. Name a constant to distinguish
+// the cases.
+#if __has_include("ur_arm_config.hpp")
+
+#include "ur_arm_config.hpp"
+
+std::filesystem::path find_resource_root() {
+    const auto module_executable_path = boost::dll::program_location();
+    const auto module_executable_directory = module_executable_path.parent_path();
+    auto data_directory = std::filesystem::canonical(module_executable_directory / k_relpath_bindir_to_datadir / "universal-robots");
+    VIAM_SDK_LOG(info) << "Universal robots module executable found in `" << module_executable_path << "; resources will be found in `"
+                       << data_directory << "`";
+    return data_directory;
+}
+
+#else
+
+std::filesystem::path find_resource_root() {
+    // get the APPDIR environment variable
+    auto* const app_dir = std::getenv("APPDIR");  // NOLINT: Yes, we know getenv isn't thread safe
+    if (!app_dir) {
+        throw std::runtime_error("required environment variable `APPDIR` unset");
+    }
+    auto data_directory = std::filesystem::path{app_dir} / "src";
+    VIAM_SDK_LOG(info) << "APPDIR is `" << app_dir << "`; resources will be found in `" << data_directory << "`";
+    return data_directory;
+}
+
+#endif
 
 #include "utils.hpp"
 
@@ -34,14 +70,14 @@ void write_joint_data(const vector6d_t& jp, const vector6d_t& jv, std::ostream& 
 URArm::state_::state_(private_,
                       std::string configured_model_type,
                       std::string host,
-                      std::string app_dir,
-                      std::string csv_output_path,
+                      std::filesystem::path resource_root,
+                      std::filesystem::path csv_output_path,
                       std::optional<double> reject_move_request_threshold_rad,
                       std::optional<double> robot_control_freq_hz,
                       const struct ports_& ports)
     : configured_model_type_{std::move(configured_model_type)},
       host_{std::move(host)},
-      app_dir_{std::move(app_dir)},
+      resource_root_{std::move(resource_root)},
       csv_output_path_{std::move(csv_output_path)},
       robot_control_freq_hz_(robot_control_freq_hz.value_or(k_default_robot_control_freq_hz)),
       reject_move_request_threshold_rad_(std::move(reject_move_request_threshold_rad)),
@@ -54,14 +90,9 @@ URArm::state_::~state_() {
 std::unique_ptr<URArm::state_> URArm::state_::create(std::string configured_model_type,
                                                      const ResourceConfig& config,
                                                      const struct ports_& ports) {
-    // get the APPDIR environment variable
-    auto* const app_dir = std::getenv("APPDIR");  // NOLINT: Yes, we know getenv isn't thread safe
-    if (!app_dir) {
-        throw std::runtime_error("required environment variable `APPDIR` unset");
-    }
-    VIAM_SDK_LOG(info) << "APPDIR: " << app_dir;
-
     auto host = find_config_attribute<std::string>(config, "host").value();
+
+    auto resource_root = find_resource_root();
 
     // If the config contains `csv_output_path`, use that, otherwise,
     // fall back to `VIAM_MODULE_DATA` as the output path, which must
@@ -87,10 +118,11 @@ std::unique_ptr<URArm::state_> URArm::state_::create(std::string configured_mode
     auto state = std::make_unique<state_>(private_{},
                                           std::move(configured_model_type),
                                           std::move(host),
-                                          std::string{app_dir},
+                                          std::move(resource_root),
                                           std::move(csv_output_path),
                                           std::move(threshold),
                                           std::move(frequency),
+
                                           ports);
 
     state->set_speed(degrees_to_radians(find_config_attribute<double>(config, "speed_degs_per_sec").value()));
@@ -159,12 +191,12 @@ vector6d_t URArm::state_::read_tcp_pose() const {
     return ephemeral_->tcp_state;
 }
 
-const std::string& URArm::state_::csv_output_path() const {
+const std::filesystem::path& URArm::state_::csv_output_path() const {
     return csv_output_path_;
 }
 
-const std::string& URArm::state_::app_dir() const {
-    return app_dir_;
+const std::filesystem::path& URArm::state_::resource_root() const {
+    return resource_root_;
 }
 
 void URArm::state_::set_speed(double speed) {

--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -2,6 +2,7 @@
 
 #include <bitset>
 #include <condition_variable>
+#include <filesystem>
 #include <future>
 #include <thread>
 #include <variant>
@@ -16,8 +17,8 @@ class URArm::state_ {
     explicit state_(private_,
                     std::string configured_model_type,
                     std::string host,
-                    std::string app_dir,
-                    std::string csv_output_path,
+                    std::filesystem::path resource_root,
+                    std::filesystem::path csv_output_path,
                     std::optional<double> reject_move_request_threshold_rad,
                     std::optional<double> robot_control_freq_hz,
                     const struct ports_& ports);
@@ -30,8 +31,8 @@ class URArm::state_ {
     vector6d_t read_joint_positions() const;
     vector6d_t read_tcp_pose() const;
 
-    const std::string& csv_output_path() const;
-    const std::string& app_dir() const;
+    const std::filesystem::path& csv_output_path() const;
+    const std::filesystem::path& resource_root() const;
 
     void set_speed(double speed);
     double get_speed() const;
@@ -93,6 +94,8 @@ class URArm::state_ {
     };
 
     struct state_disconnected_ : public state_event_handler_base_<state_disconnected_> {
+        state_disconnected_() = default;
+
         static std::string_view name();
         std::string describe() const;
         std::chrono::milliseconds get_timeout() const;
@@ -281,8 +284,8 @@ class URArm::state_ {
 
     const std::string configured_model_type_;
     const std::string host_;
-    const std::string app_dir_;
-    const std::string csv_output_path_;
+    const std::filesystem::path resource_root_;
+    const std::filesystem::path csv_output_path_;
     const double robot_control_freq_hz_;
 
     // If this field ever becomes mutable, the accessors for it must

--- a/src/viam/ur/module/ur_arm_state_disconnected.cpp
+++ b/src/viam/ur/module/ur_arm_state_disconnected.cpp
@@ -1,13 +1,5 @@
 #include "ur_arm_state.hpp"
 
-namespace {
-
-// locations of files necessary to build module, specified as relative paths
-constexpr char k_output_recipe[] = "/src/control/rtde_output_recipe.txt";
-constexpr char k_input_recipe[] = "/src/control/rtde_input_recipe.txt";
-
-}  // namespace
-
 // NOLINTBEGIN(readability-convert-member-functions-to-static)
 
 std::string_view URArm::state_::state_disconnected_::name() {
@@ -73,15 +65,18 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_disconnected_:
         }
     }
 
-    constexpr char k_script_file[] = "/src/control/external_control.urscript";
+    // locations of files necessary to build module, specified as relative paths
+    constexpr char k_script_file[] = "control/external_control.urscript";
+    constexpr char k_output_recipe[] = "control/rtde_output_recipe.txt";
+    constexpr char k_input_recipe[] = "control/rtde_input_recipe.txt";
 
     VIAM_SDK_LOG(info) << "disconnected: attempting recovery: instantiating new UrDriver";
     // Now the robot is ready to receive a program
     auto ur_cfg = urcl::UrDriverConfiguration{};
     ur_cfg.robot_ip = state.host_;
-    ur_cfg.script_file = state.app_dir_ + k_script_file;
-    ur_cfg.output_recipe_file = state.app_dir_ + k_output_recipe;
-    ur_cfg.input_recipe_file = state.app_dir_ + k_input_recipe;
+    ur_cfg.script_file = state.resource_root_ / k_script_file;
+    ur_cfg.output_recipe_file = state.resource_root_ / k_output_recipe;
+    ur_cfg.input_recipe_file = state.resource_root_ / k_input_recipe;
     ur_cfg.handle_program_state = [&running_flag = arm_connection->program_running_flag](bool running) {
         VIAM_SDK_LOG(info) << "UR program is " << (running ? "running" : "not running");
         running_flag.store(running, std::memory_order_release);


### PR DESCRIPTION
This is the basic support for direct builds of the driver outside of an appimage. There is no packaging for such a build - you just get an install tree. Optionally, you can turn that into a `module.tar.gz`, which will work on the system where it was built, but not elsewhere, since it has dynamic dependencies on system packages like boost, gRPC, etc.

I've hand tested this on both macOS and linux with some success, and confirmed that I can also still build the appimage way.

As always, I'll leave some comments along the way.