### PR TITLE
[RSDK-11923] Do connection establishment out of disconnected with a background thread

### DIFF
--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <filesystem>
 #include <future>
+#include <optional>
 #include <thread>
 #include <variant>
 
@@ -51,6 +52,7 @@ class URArm::state_ {
     std::optional<std::shared_future<void>> cancel_move_request();
 
    private:
+    struct arm_connection_;
     struct state_disconnected_;
     friend struct state_disconnected_;
 
@@ -109,9 +111,12 @@ class URArm::state_ {
 
         using state_event_handler_base_<state_disconnected_>::handle_event;
 
+        std::unique_ptr<arm_connection_> connect_(state_& state);
+
         // track how often we attempt to reconnect.
         // We will use this to limit how often logs spam during expected behaviors.
         int reconnect_attempts{-1};
+        std::optional<std::future<std::unique_ptr<arm_connection_>>> pending_connection;
     };
 
     struct arm_connection_ {

--- a/src/viam/ur/module/ur_arm_state_connected.cpp
+++ b/src/viam/ur/module/ur_arm_state_connected.cpp
@@ -19,7 +19,7 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::se
 std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::recv_arm_data(state_& state) {
     const auto prior_robot_status_bits = std::exchange(arm_conn_->robot_status_bits, std::nullopt);
     const auto prior_safety_status_bits = std::exchange(arm_conn_->safety_status_bits, std::nullopt);
-    // arm_conn_->data_package
+
     auto new_packet = arm_conn_->driver->getDataPackage();
     if (!new_packet) {
         consecutive_missed_packets++;


### PR DESCRIPTION
This allows calls to `is_moving` to be answered while connection is in progress, since we don't block with the state mutex in `disconnected::upgrade_downgrade` but instead repeatedly invoke it after re-acquiring the mutex.

Note that this is a partial solution, because we still have blocking connect calls in the `state_independent_`. The next step for this ticket, in a follow-up PR, will be to transition through the disconnected state when the system traverses a local-to- remote or remote-to-local edge, which will centralize all connection establishment onto this concurrent scheme. My hope is that this will allow us to significantly simplify the logic in the independent state, ensuring that we get accurate answers when querying the dashboard for the local/remote state.