### PR TITLE
[RSDK-11908] get tcp forces

### DIFF
--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -381,7 +381,7 @@ URArm::KinematicsData URArm::get_kinematics(const ProtoStruct&) {
         throw std::runtime_error(str(boost::format("no kinematics file known for model '%1'") % model_.to_string()));
     }();
 
-    constexpr char kSvaFileTemplate[] = "kinematics/%2%.json";
+    constexpr char kSvaFileTemplate[] = "kinematics/%1%.json";
     const auto sva_file_path = current_state_->resource_root() / str(boost::format(kSvaFileTemplate) % model_string);
 
     // Open the file in binary mode
@@ -412,6 +412,7 @@ ProtoStruct URArm::do_command(const ProtoStruct& command) {
 
     ProtoStruct resp = ProtoStruct{};
 
+    constexpr char k_get_tcp_force_key[] = "get_tcp_forces";
     // NOTE: Changes to these values will not be effective for any
     // trajectory currently being planned, and will only affect
     // trajectory planning initiated after these values have been
@@ -429,6 +430,15 @@ ProtoStruct URArm::do_command(const ProtoStruct& command) {
             const double val = *kv.second.get<double>();
             current_state_->set_acceleration(degrees_to_radians(val));
             resp.emplace(k_acc_key, val);
+        }
+        if (kv.first == k_get_tcp_force_key) {
+            const auto forces = current_state_->read_tcp_forces();
+            resp.emplace("Fx_N", forces[0]);
+            resp.emplace("Fy_N", forces[1]);
+            resp.emplace("Fz_N", forces[2]);
+            resp.emplace("TRx_Nm", forces[3]);
+            resp.emplace("TRy_Nm", forces[4]);
+            resp.emplace("TRz_Nm", forces[5]);
         }
     }
 

--- a/src/viam/ur/module/ur_arm_state.cpp
+++ b/src/viam/ur/module/ur_arm_state.cpp
@@ -208,6 +208,16 @@ vector6d_t URArm::state_::read_tcp_pose() const {
     return ephemeral_->tcp_state;
 }
 
+vector6d_t URArm::state_::read_tcp_forces() const {
+    const std::lock_guard lock{mutex_};
+    if (!ephemeral_) {
+        std::ostringstream buffer;
+        buffer << "read_tcp_forces: tcp forces are not currently known; current state: " << describe_();
+        throw std::runtime_error(buffer.str());
+    }
+    return ephemeral_->tcp_forces;
+}
+
 const std::filesystem::path& URArm::state_::csv_output_path() const {
     return csv_output_path_;
 }

--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -31,6 +31,7 @@ class URArm::state_ {
     const std::optional<double>& get_reject_move_request_threshold_rad() const;
     vector6d_t read_joint_positions() const;
     vector6d_t read_tcp_pose() const;
+    vector6d_t read_tcp_forces() const;
 
     const std::filesystem::path& csv_output_path() const;
     const std::filesystem::path& resource_root() const;
@@ -318,6 +319,7 @@ class URArm::state_ {
         vector6d_t joint_positions;
         vector6d_t joint_velocities;
         vector6d_t tcp_state;
+        vector6d_t tcp_forces;
     };
     std::optional<struct ephemeral_> ephemeral_;
 };

--- a/src/viam/ur/module/ur_arm_state_connected.cpp
+++ b/src/viam/ur/module/ur_arm_state_connected.cpp
@@ -66,6 +66,7 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::re
     static const std::string k_joints_position_key = "actual_q";
     static const std::string k_joints_velocity_key = "actual_qd";
     static const std::string k_tcp_key = "actual_TCP_pose";
+    static const std::string k_tcp_force_key = "actual_TCP_force";
 
     bool data_good = true;
     vector6d_t joint_positions{};
@@ -87,10 +88,16 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::re
         data_good = false;
     }
 
+    vector6d_t tcp_force{};
+    if (!arm_conn_->data_package->getData(k_tcp_force_key, tcp_force)) {
+        VIAM_SDK_LOG(warn) << "getData(\"actual_TCP_force\") returned false - end effector force will not be available";
+        data_good = false;
+    }
+
     // For consistency, update cached data only after all getData
     // calls succeed.
     if (data_good) {
-        state.ephemeral_ = {std::move(joint_positions), std::move(joint_velocities), std::move(tcp_state)};
+        state.ephemeral_ = {std::move(joint_positions), std::move(joint_velocities), std::move(tcp_state), std::move(tcp_force)};
     }
 
     return std::nullopt;


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-11908

we can now get forces on the arm. here is an example from chris's force testing rig. Unfortunately, the load cells weren't calibrated at the time so we cannot compare numbers, but the forces appear to make sense. 

I also do not have a sense for whether we can determine if the arm is "flat" with this. maybe theres an unexpected jump in forces somewhere but we would need actual data to determine that

<img width="1189" height="690" alt="arm_force" src="https://github.com/user-attachments/assets/694a69bf-2630-4c9d-8b46-beec01f1d185" />
