### PR TITLE
RSDK-11985 - UR20 kinematics file is incorrect

### DIFF
--- a/src/kinematics/ur20.json
+++ b/src/kinematics/ur20.json
@@ -10,7 +10,7 @@
                 "value": {
                     "pitch": 0,
                     "roll": 0,
-                    "yaw": 3.141592653589793
+                    "yaw": 0
                 }
             },
             "translation": {

--- a/src/kinematics/ur20.urdf
+++ b/src/kinematics/ur20.urdf
@@ -8,7 +8,7 @@
   <joint name="base_link-base_link_inertia" type="fixed">
     <parent link="base_link"/>
     <child link="base_link_inertia"/>
-    <origin rpy="0 0 3.141592653589793" xyz="0 0 0"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
   </joint>
 
   <link name="base_link_inertia"/>


### PR DESCRIPTION
RSDK-11985 - UR20 kinematics file is incorrect

This is so that
```
model.transform(current inputs) == ur20.EndPostion()
```

edit: once this is merged the following would need to be updated for a sanding robot:
1) picture inputs 
2) calibration inputs
3) location of region of interest