### PR TITLE
[RSDK-12645] Bump urcl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ include(FetchContent)
 FetchContent_Declare(
   Universal_Robots_Client_Library
   GIT_REPOSITORY https://github.com/UniversalRobots/Universal_Robots_Client_Library
-  GIT_TAG        2.2.0
+  GIT_TAG        2.8.0
   GIT_SHALLOW TRUE
   SYSTEM
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ include(FetchContent)
 FetchContent_Declare(
   Universal_Robots_Client_Library
   GIT_REPOSITORY https://github.com/UniversalRobots/Universal_Robots_Client_Library
-  GIT_TAG        2.8.0
+  GIT_TAG        2.9.0
   GIT_SHALLOW TRUE
   SYSTEM
 )

--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -182,7 +182,7 @@ class URArm::state_ {
 
         ~arm_connection_();
 
-        std::unique_ptr<urcl::DashboardClient> dashboard;
+        std::unique_ptr<DashboardClient> dashboard;
         std::unique_ptr<UrDriver> driver;
         std::unique_ptr<rtde_interface::DataPackage> data_package;
         std::optional<std::bitset<k_num_robot_status_bits>> robot_status_bits;

--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -182,7 +182,7 @@ class URArm::state_ {
 
         ~arm_connection_();
 
-        std::unique_ptr<DashboardClient> dashboard;
+        std::unique_ptr<urcl::DashboardClient> dashboard;
         std::unique_ptr<UrDriver> driver;
         std::unique_ptr<rtde_interface::DataPackage> data_package;
         std::optional<std::bitset<k_num_robot_status_bits>> robot_status_bits;

--- a/src/viam/ur/module/ur_arm_state_connected.cpp
+++ b/src/viam/ur/module/ur_arm_state_connected.cpp
@@ -21,8 +21,8 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::re
     const auto prior_robot_status_bits = std::exchange(arm_conn_->robot_status_bits, std::nullopt);
     const auto prior_safety_status_bits = std::exchange(arm_conn_->safety_status_bits, std::nullopt);
 
-    auto new_packet = arm_conn_->driver->getDataPackage();
-    if (!new_packet) {
+    // On failure, getDataPackage leaves data_package unmodified, so we retain the last good packet.
+    if (!arm_conn_->driver->getDataPackage(*arm_conn_->data_package)) {
         consecutive_missed_packets++;
         // how many packets we can drop before restarting the connection
         if (consecutive_missed_packets > 3) {
@@ -31,7 +31,6 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_connected_::re
         }
         VIAM_SDK_LOG(warn) << "Failed to read a data package from the arm: missed a packet: " << consecutive_missed_packets;
     } else {
-        arm_conn_->data_package = std::move(new_packet);
         consecutive_missed_packets = 0;
     }
 

--- a/src/viam/ur/module/ur_arm_state_controlled.cpp
+++ b/src/viam/ur/module/ur_arm_state_controlled.cpp
@@ -33,11 +33,6 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_controlled_::u
         return event_stop_detected_{};
     }
 
-    if (arm_conn_->dashboard->getState() != urcl::comm::SocketState::Connected) {
-        VIAM_SDK_LOG(warn) << "While in state " << describe() << ", dashboard client is disconnected; dropping connection";
-        return event_connection_lost_::dashboard_communication_failure();
-    }
-
     // If we get anything but a positive answer from the dashboard
     // that we are in remote control, assume that we need to
     // completely re-create our connection, since sockets aren't

--- a/src/viam/ur/module/ur_arm_state_disconnected.cpp
+++ b/src/viam/ur/module/ur_arm_state_disconnected.cpp
@@ -155,7 +155,7 @@ std::unique_ptr<URArm::state_::arm_connection_> URArm::state_::state_disconnecte
     }
 
     VIAM_SDK_LOG(debug) << "While in state " << describe()
-                       << ", recovery appears to have been successful; transitioning to independent mode";
+                        << ", recovery appears to have been successful; transitioning to independent mode";
     return arm_connection;
 }
 

--- a/src/viam/ur/module/ur_arm_state_disconnected.cpp
+++ b/src/viam/ur/module/ur_arm_state_disconnected.cpp
@@ -154,7 +154,7 @@ std::unique_ptr<URArm::state_::arm_connection_> URArm::state_::state_disconnecte
         throw std::runtime_error("could not read data package from newly established driver connection ");
     }
 
-    VIAM_SDK_LOG(info) << "While in state " << describe()
+    VIAM_SDK_LOG(debug) << "While in state " << describe()
                        << ", recovery appears to have been successful; transitioning to independent mode";
     return arm_connection;
 }

--- a/src/viam/ur/module/ur_arm_state_disconnected.cpp
+++ b/src/viam/ur/module/ur_arm_state_disconnected.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<URArm::state_::arm_connection_> URArm::state_::state_disconnecte
         VIAM_SDK_LOG(info) << "While in state " << describe() << ", attempting to reconnect";
     }
 
-    arm_connection->dashboard = std::make_unique<urcl::DashboardClient>(state.host_);
+    arm_connection->dashboard = std::make_unique<DashboardClient>(state.host_);
     if (reconnect_attempts % k_log_at_n_attempts == 0) {
         VIAM_SDK_LOG(debug) << "While in state " << describe() << ", attempting to reconnect: trying to connect to dashboard";
     }

--- a/src/viam/ur/module/ur_arm_state_disconnected.cpp
+++ b/src/viam/ur/module/ur_arm_state_disconnected.cpp
@@ -149,14 +149,13 @@ std::unique_ptr<URArm::state_::arm_connection_> URArm::state_::state_disconnecte
     arm_connection->driver->startRTDECommunication();
 
     VIAM_SDK_LOG(debug) << "While in state " << describe() << ", attempting to reconnect: attempting to read a data package from the arm";
-    arm_connection->data_package = std::make_unique<urcl::rtde_interface::DataPackage>(
-        arm_connection->driver->getRTDEOutputRecipe());
+    arm_connection->data_package = std::make_unique<urcl::rtde_interface::DataPackage>(arm_connection->driver->getRTDEOutputRecipe());
     if (!arm_connection->driver->getDataPackage(*arm_connection->data_package)) {
         throw std::runtime_error("could not read data package from newly established driver connection ");
     }
 
-    VIAM_SDK_LOG(debug) << "While in state " << describe()
-                        << ", recovery appears to have been successful; transitioning to independent mode";
+    VIAM_SDK_LOG(info) << "While in state " << describe()
+                       << ", recovery appears to have been successful; transitioning to independent mode";
     return arm_connection;
 }
 

--- a/src/viam/ur/module/ur_arm_state_disconnected.cpp
+++ b/src/viam/ur/module/ur_arm_state_disconnected.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<URArm::state_::arm_connection_> URArm::state_::state_disconnecte
         VIAM_SDK_LOG(info) << "While in state " << describe() << ", attempting to reconnect";
     }
 
-    arm_connection->dashboard = std::make_unique<DashboardClient>(state.host_);
+    arm_connection->dashboard = std::make_unique<urcl::DashboardClient>(state.host_);
     if (reconnect_attempts % k_log_at_n_attempts == 0) {
         VIAM_SDK_LOG(debug) << "While in state " << describe() << ", attempting to reconnect: trying to connect to dashboard";
     }
@@ -149,7 +149,9 @@ std::unique_ptr<URArm::state_::arm_connection_> URArm::state_::state_disconnecte
     arm_connection->driver->startRTDECommunication();
 
     VIAM_SDK_LOG(debug) << "While in state " << describe() << ", attempting to reconnect: attempting to read a data package from the arm";
-    if (!arm_connection->driver->getDataPackage()) {
+    arm_connection->data_package = std::make_unique<urcl::rtde_interface::DataPackage>(
+        arm_connection->driver->getRTDEOutputRecipe());
+    if (!arm_connection->driver->getDataPackage(*arm_connection->data_package)) {
         throw std::runtime_error("could not read data package from newly established driver connection ");
     }
 

--- a/src/viam/ur/module/ur_arm_state_independent.cpp
+++ b/src/viam/ur/module/ur_arm_state_independent.cpp
@@ -86,11 +86,6 @@ std::optional<URArm::state_::event_variant_> URArm::state_::state_independent_::
         return event_connection_lost_::data_communication_failure();
     }
 
-    if (arm_conn_->dashboard->getState() != urcl::comm::SocketState::Connected) {
-        VIAM_SDK_LOG(debug) << "While in state " << describe() << ", dashboard client is disconnected; dropping connection";
-        return event_connection_lost_::dashboard_communication_failure();
-    }
-
     // If we aren't stopped, but the safety flags say we are, become stopped immediately.
     if (!stopped() && !arm_conn_->safety_status_bits->test(static_cast<size_t>(urtde::UrRtdeSafetyStatusBits::IS_NORMAL_MODE))) {
         return event_stop_detected_{};


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-12645

  Bump Universal Robots Client Library from 2.2.0 to 2.9.0                              
                                                                                        
  This PR updates the urcl dependency and adapts the module to its changed API.         
                                                                                        
  API changes (urcl 2.x)                                                                
                                                                                        
  - getDataPackage() no longer returns a unique_ptr<DataPackage> — it now takes a       
  pre-allocated DataPackage& and returns bool. Updated all call sites in
  state_connected_ and state_disconnected_ accordingly. On failure, data_package is left
   unmodified so the last good packet is retained.          
  - DashboardClient moved into the urcl:: namespace. Updated construction and type
  annotations in arm_connection_ and state_disconnected_.                               
   
  Behavioral changes                                                                    

  - Updates urscript controls file to handle trajectory cancellation correctly(no more pstops on cancel)                                                         
  - Removed dashboard socket-state checks in state_controlled_ and state_independent_.  
  These checked dashboard->getState() == Connected and dropped the connection if not. now we just rely on errors from urcl to detect the change. since we already kicked into disconnected when we would detect local mode its really not that different
  - The fix for silent network loss (wifi-drop causing RTDEClient::~RTDEClient() to hang
   indefinitely)