### PR TITLE
[RSDK-13667] Upgrade to trajex 0.100.0-rc5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ find_package(Boost CONFIG REQUIRED
 FetchContent_Declare(
   trajex
   GIT_REPOSITORY https://github.com/viam-modules/trajex.git
-  GIT_TAG v0.100.0-rc4
+  GIT_TAG v0.100.0-rc5
   GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(trajex)


### PR DESCRIPTION
The counterpart to https://github.com/viam-modules/trajex/pull/11 which I will tag as rc5 once it merges.