### PR TITLE
[RSDK-14052] Don't fail the build on unknown warning options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ function(viam_ur_apply_wall_werror target_name)
       -Wunused
       # TODO(RSDK-11300): rm after upgrading boost https://github.com/boostorg/mpl/issues/69
       -Wno-enum-constexpr-conversion
+      -Wno-unknown-warning-option
     )
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(${target_name} PRIVATE /W4 /WX)


### PR DESCRIPTION
Same as https://github.com/viam-modules/trajex/pull/18.

I've decided against upgrading the builders for trajex and universal robots to the macos26 specific builder. According to github, it will become -latest in the next couple weeks, and I build these two projects all the time locally on my (now XCode 26.5) mac machine, so we have coverage until we get naturally upgraded by way of -latest.