### PR TITLE
RSDK-14141 Add zero_ftsensor DoCommand to zero the wrist force/torque sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ example output:
 }
 ```
 
+#### zero_ftsensor DoCommand
+
+`zero_ftsensor` zeroes (tares) the wrist force/torque sensor at the controller, so subsequent `get_tcp_forces_base`/`get_tcp_forces_tool` readings are relative to the current load and pose. This is an **e-Series-only** command (UR5e/UR10e/etc.); it is not supported on CB-series robots. The arm must be in a controllable state — the external control script must be running — otherwise the command throws. For an accurate tare, the robot must be **stationary and not in contact** with anything when the command is called, since any contact or motion wrench at that moment is baked into the offset. Note that the tare applies to the current pose only; cross-pose gravity compensation is the job of the payload mass/center-of-gravity installation setting, not this command.
+
+```json
+{
+  "zero_ftsensor": ""
+}
+```
+
 #### is_controllable_state DoCommand
 
 `is_controllable_state` returns a boolean that informs a user whether the arm is in a controllable state and ready to receive commands.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ example output:
 
 #### zero_ftsensor DoCommand
 
-`zero_ftsensor` zeroes (tares) the wrist force/torque sensor at the controller, so subsequent `get_tcp_forces_base`/`get_tcp_forces_tool` readings are relative to the current load and pose. This is an **e-Series-only** command (UR5e/UR10e/etc.); it is not supported on CB-series robots. The arm must be in a controllable state — the external control script must be running — otherwise the command throws. For an accurate tare, the robot must be **stationary and not in contact** with anything when the command is called, since any contact or motion wrench at that moment is baked into the offset. Note that the tare applies to the current pose only; cross-pose gravity compensation is the job of the payload mass/center-of-gravity installation setting, not this command.
+`zero_ftsensor` zeroes (tares) the wrist force/torque sensor at the controller, so subsequent `get_tcp_forces_base`/`get_tcp_forces_tool` readings are relative to the current load and pose. This is an **e-Series-only** command (UR5e/UR10e/etc.); it is not supported on CB-series robots. The arm must be in a controllable state, otherwise the command will not work. For an accurate tare, the robot must be **stationary and not in contact** with anything when the command is called.
 
 ```json
 {

--- a/src/viam/ur/module/ur_arm.cpp
+++ b/src/viam/ur/module/ur_arm.cpp
@@ -527,6 +527,7 @@ ProtoStruct URArm::do_command(const ProtoStruct& command) {
     constexpr char k_get_tcp_forces_base_key[] = "get_tcp_forces_base";
     constexpr char k_get_tcp_forces_tool_key[] = "get_tcp_forces_tool";
     constexpr char k_clear_pstop[] = "clear_pstop";
+    constexpr char k_zero_ftsensor[] = "zero_ftsensor";
     constexpr char k_is_controllable[] = "is_controllable_state";
     constexpr char k_get_state_description[] = "get_state_description";
     constexpr char k_get_calibrated_dh_params[] = "get_calibrated_dh_params";
@@ -592,6 +593,9 @@ ProtoStruct URArm::do_command(const ProtoStruct& command) {
         } else if (kv.first == k_clear_pstop) {
             current_state_->clear_pstop();
             resp.emplace(k_clear_pstop, "protective stop cleared");
+        } else if (kv.first == k_zero_ftsensor) {
+            current_state_->zero_ftsensor();
+            resp.emplace(k_zero_ftsensor, "force-torque sensor zeroed");
         } else if (kv.first == k_is_controllable) {
             if (!cached_controlled_info) {
                 cached_controlled_info = controlled_info{};

--- a/src/viam/ur/module/ur_arm_state.cpp
+++ b/src/viam/ur/module/ur_arm_state.cpp
@@ -603,6 +603,11 @@ void URArm::state_::clear_pstop() const {
     std::visit([](auto& state) { state.clear_pstop(); }, current_state_);
 }
 
+void URArm::state_::zero_ftsensor() const {
+    const std::lock_guard lock{mutex_};
+    std::visit([](auto& state) { state.zero_ftsensor(); }, current_state_);
+}
+
 template <typename T>
 void URArm::state_::emit_event_(T&& event) {
     auto new_state = std::visit(

--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -96,6 +96,7 @@ class URArm::state_ {
     double get_trajectory_sampling_freq_hz() const;
 
     void clear_pstop() const;
+    void zero_ftsensor() const;
 
     size_t get_move_epoch() const;
 
@@ -195,6 +196,7 @@ class URArm::state_ {
         std::string describe() const;
         std::chrono::milliseconds get_timeout() const;
         void clear_pstop() const;
+        void zero_ftsensor() const;
 
         std::optional<event_variant_> recv_arm_data(state_&);
         std::optional<event_variant_> upgrade_downgrade(state_& state);
@@ -286,6 +288,7 @@ class URArm::state_ {
         std::string describe() const;
         using state_connected_::get_timeout;
         void clear_pstop() const;
+        void zero_ftsensor() const;
 
         using state_connected_::recv_arm_data;
         std::optional<event_variant_> upgrade_downgrade(state_&);
@@ -307,6 +310,7 @@ class URArm::state_ {
         std::string describe() const;
         using state_connected_::get_timeout;
         void clear_pstop() const;
+        void zero_ftsensor() const;
 
         using state_connected_::recv_arm_data;
         std::optional<event_variant_> upgrade_downgrade(state_&);

--- a/src/viam/ur/module/ur_arm_state_controlled.cpp
+++ b/src/viam/ur/module/ur_arm_state_controlled.cpp
@@ -225,9 +225,6 @@ void URArm::state_::state_controlled_::clear_pstop() const {
 }
 
 void URArm::state_::state_controlled_::zero_ftsensor() const {
-    // The control script is live in this state, so urcl::UrDriver::zeroFTSensor() takes the
-    // fast in-band path. It returns false on a CB-series robot (e-Series only) or if the
-    // underlying script write fails.
     if (!arm_conn_->driver->zeroFTSensor()) {
         throw std::runtime_error(
             "failed to zero the force-torque sensor "

--- a/src/viam/ur/module/ur_arm_state_controlled.cpp
+++ b/src/viam/ur/module/ur_arm_state_controlled.cpp
@@ -224,4 +224,15 @@ void URArm::state_::state_controlled_::clear_pstop() const {
     throw std::runtime_error("cannot clear the protective stop, arm is not currently pstopped");
 }
 
+void URArm::state_::state_controlled_::zero_ftsensor() const {
+    // The control script is live in this state, so urcl::UrDriver::zeroFTSensor() takes the
+    // fast in-band path. It returns false on a CB-series robot (e-Series only) or if the
+    // underlying script write fails.
+    if (!arm_conn_->driver->zeroFTSensor()) {
+        throw std::runtime_error(
+            "failed to zero the force-torque sensor "
+            "(requires an e-Series robot with the external control script running)");
+    }
+}
+
 // NOLINTEND(readability-convert-member-functions-to-static)

--- a/src/viam/ur/module/ur_arm_state_disconnected.cpp
+++ b/src/viam/ur/module/ur_arm_state_disconnected.cpp
@@ -195,4 +195,8 @@ void URArm::state_::state_disconnected_::clear_pstop() const {
     throw std::runtime_error("cannot clear the protective stop, arm is currently disconnected");
 }
 
+void URArm::state_::state_disconnected_::zero_ftsensor() const {
+    throw std::runtime_error("cannot zero the force-torque sensor, arm is currently disconnected");
+}
+
 // NOLINTEND(readability-convert-member-functions-to-static)

--- a/src/viam/ur/module/ur_arm_state_independent.cpp
+++ b/src/viam/ur/module/ur_arm_state_independent.cpp
@@ -355,8 +355,12 @@ void URArm::state_::state_independent_::clear_pstop() const {
 
 void URArm::state_::state_independent_::zero_ftsensor() const {
     // In this state the external control script is not running (the arm is stopped and/or in
-    // local mode), so urcl would fall back to a remote_control-mode script send that fails in
-    // local mode. Refuse rather than silently no-op; the caller must reach a controllable state.
+    // local mode), so urcl can't take its fast in-band path and falls back to a plain
+    // remote_control-mode script send. That fallback fails outright in local mode, and even
+    // where it could succeed (stopped but still in remote control) a tare here is semantically
+    // dubious: the FT sensor should be zeroed in a stable, gravity-loaded pose before work
+    // begins, which is the controlled state. So we refuse explicitly rather than silently
+    // no-op or tare a braked arm; the caller must reach a controllable state first.
     throw std::runtime_error(
         "cannot zero the force-torque sensor, arm is not in a controllable state "
         "(it is stopped or in local mode; the external control script must be running)");

--- a/src/viam/ur/module/ur_arm_state_independent.cpp
+++ b/src/viam/ur/module/ur_arm_state_independent.cpp
@@ -354,13 +354,6 @@ void URArm::state_::state_independent_::clear_pstop() const {
 }
 
 void URArm::state_::state_independent_::zero_ftsensor() const {
-    // In this state the external control script is not running (the arm is stopped and/or in
-    // local mode), so urcl can't take its fast in-band path and falls back to a plain
-    // remote_control-mode script send. That fallback fails outright in local mode, and even
-    // where it could succeed (stopped but still in remote control) a tare here is semantically
-    // dubious: the FT sensor should be zeroed in a stable, gravity-loaded pose before work
-    // begins, which is the controlled state. So we refuse explicitly rather than silently
-    // no-op or tare a braked arm; the caller must reach a controllable state first.
     throw std::runtime_error(
         "cannot zero the force-torque sensor, arm is not in a controllable state "
         "(it is stopped or in local mode; the external control script must be running)");

--- a/src/viam/ur/module/ur_arm_state_independent.cpp
+++ b/src/viam/ur/module/ur_arm_state_independent.cpp
@@ -353,4 +353,13 @@ void URArm::state_::state_independent_::clear_pstop() const {
     throw std::runtime_error("failed to clear the protective stop");
 }
 
+void URArm::state_::state_independent_::zero_ftsensor() const {
+    // In this state the external control script is not running (the arm is stopped and/or in
+    // local mode), so urcl would fall back to a remote_control-mode script send that fails in
+    // local mode. Refuse rather than silently no-op; the caller must reach a controllable state.
+    throw std::runtime_error(
+        "cannot zero the force-torque sensor, arm is not in a controllable state "
+        "(it is stopped or in local mode; the external control script must be running)");
+}
+
 // NOLINTEND(readability-convert-member-functions-to-static)


### PR DESCRIPTION
## Summary

Adds a no-argument `zero_ftsensor` arm `DoCommand` that tares the UR e-Series wrist force/torque sensor at the controller. After it runs, the existing `get_tcp_forces_base` / `get_tcp_forces_tool` readings report ~0 in the current pose, giving consumers a one-call hardware tare over the same `DoCommand` surface instead of doing a software offset-subtraction or taring out-of-band from the teach pendant.
