### PR TITLE
telemetry: read the trace ID from a configurable metadata field

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following attributes are available for `viam:universal-robots` arms:
 | `prefer_precomputed_accelerations` | bool | Optional | When true, trajectory points are sent to the robot with precomputed accelerations from the TOTG planner, enabling higher-order spline interpolation and continuous acceleration at waypoints. Only takes effect when `enable_new_trajectory_planner` is also true. **Default false** |
 | `telemetry_output_path` | string | Optional | Path for writing telemetry data files (waypoints, trajectories, joint positions, failure diagnostics). Files are written in CSV and JSON formats with ISO8601 timestamps. **Default: VIAM_MODULE_DATA environment variable** |
 | `telemetry_output_path_append_traceid` | bool or string | Optional | Controls whether and how the trace ID from the current span is appended to the telemetry output path. When set to `true`, appends the raw trace ID as a subdirectory. When set to a template string containing `{trace_id}`, the placeholder is replaced with the actual trace ID, giving full control over the subdirectory name (e.g. `"tag={trace_id}"`, `"{trace_id}-run"`, `"traces/{trace_id}/data"`). **Default: false** |
+| `traceid_metadata_key` | string | Optional | The request-metadata field to read the trace ID from. When set, the value of that field is used directly as the trace ID; keys for metadata propagated by RDK are prefixed with `viam-metadata-`. When unset (and `telemetry_output_path_append_traceid` is set), the trace ID is parsed from the `traceparent` header instead. |
 
 ### Example configurations:
 

--- a/src/viam/ur/module/ur_arm_state.cpp
+++ b/src/viam/ur/module/ur_arm_state.cpp
@@ -44,6 +44,7 @@ URArm::state_::state_(private_,
                       std::optional<vector6d_t> max_acceleration_limits,
                       double trajectory_sampling_freq_hz,
                       std::string telemetry_output_path_append_traceid_template,
+                      std::string traceid_metadata_key,
                       const struct ports_& ports)
     : configured_model_{std::move(configured_model)},
       resource_name_{std::move(resource_name)},
@@ -65,7 +66,8 @@ URArm::state_::state_(private_,
       max_velocity_limits_(std::move(max_velocity_limits)),
       max_acceleration_limits_(std::move(max_acceleration_limits)),
       trajectory_sampling_freq_hz_(trajectory_sampling_freq_hz),
-      telemetry_output_path_append_traceid_template_(std::move(telemetry_output_path_append_traceid_template)) {
+      telemetry_output_path_append_traceid_template_(std::move(telemetry_output_path_append_traceid_template)),
+      traceid_metadata_key_(std::move(traceid_metadata_key)) {
     // Initialize the kinematics promise/future pair so that
     // `kinematics_future_.valid()` is unconditionally true for the rest of
     // `state_`'s lifetime. The producer side (see
@@ -164,6 +166,10 @@ std::unique_ptr<URArm::state_> URArm::state_::create(UrArmModel configured_model
         return {};
     }();
 
+    // Parse `traceid_metadata_key` — the request-metadata field the trace id is read from. When
+    // unset, the trace id is derived from the traceparent header (see telemetry_output_path).
+    const auto traceid_metadata_key = find_config_attribute<std::string>(config, "traceid_metadata_key").value_or("");
+
     // Look for the optional settings to place an upper bound on what velocity and acceleration limits may be
     // configured, or set via DoCommand or applied via MoveOptions. Note that the parse/validate function automatically
     // converts from degrees to radians.
@@ -199,6 +205,7 @@ std::unique_ptr<URArm::state_> URArm::state_::create(UrArmModel configured_model
                                           std::move(max_acceleration_limits),
                                           trajectory_sampling_freq_hz,
                                           telemetry_output_path_append_traceid_template,
+                                          traceid_metadata_key,
                                           ports);
 
     state->set_velocity_limits(parse_and_validate_joint_limits(config, "speed_degs_per_sec"));
@@ -315,15 +322,22 @@ std::filesystem::path URArm::state_::telemetry_output_path() const {
         return telemetry_output_path_;
     }
 
-    const auto traceparent_values = observer->get_client_metadata_field_values("traceparent");
-    if (traceparent_values.empty()) {
-        // No traceparent header, return base path
-        return telemetry_output_path_;
+    // Resolve the trace-id: read it directly from the configured request-metadata field if one is
+    // set, otherwise parse it from the traceparent header (the default).
+    std::optional<std::string> trace_id;
+    if (!traceid_metadata_key_.empty()) {
+        const auto values = observer->get_client_metadata_field_values(traceid_metadata_key_);
+        if (!values.empty()) {
+            trace_id = values[0];
+        }
+    } else {
+        const auto traceparent_values = observer->get_client_metadata_field_values("traceparent");
+        if (!traceparent_values.empty()) {
+            trace_id = extract_trace_id_from_traceparent(traceparent_values[0]);
+        }
     }
-
-    const auto trace_id = extract_trace_id_from_traceparent(traceparent_values[0]);
     if (!trace_id) {
-        // Failed to parse trace-id, return base path
+        // No trace-id available, return base path
         return telemetry_output_path_;
     }
 

--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -44,6 +44,7 @@ class URArm::state_ {
                     std::optional<vector6d_t> max_acceleration_limits,
                     double trajectory_sampling_freq_hz,
                     std::string telemetry_output_path_append_traceid_template,
+                    std::string traceid_metadata_key,
                     const struct ports_& ports);
     ~state_();
 
@@ -510,6 +511,7 @@ class URArm::state_ {
     const std::optional<vector6d_t> max_acceleration_limits_;
     const double trajectory_sampling_freq_hz_;
     const std::string telemetry_output_path_append_traceid_template_;
+    const std::string traceid_metadata_key_;
 
     mutable std::mutex mutex_;
     state_variant_ current_state_{state_disconnected_{}};


### PR DESCRIPTION
The telemetry output path is tagged by the trace ID parsed out of the incoming `traceparent` header. Callers that have moved off OpenTelemetry to RDK's request-metadata propagation no longer set `traceparent`, so there's no way to tag telemetry with the identifier they do propagate.

Add an optional `traceid_metadata_key` config attribute. When set, the trace ID is read directly from that request-metadata field; when unset, it falls back to parsing the `traceparent` header as before. The existing `telemetry_output_path_append_traceid` / `{trace_id}` behavior is unchanged, keeping the module domain-agnostic — an operator configures the key per arm to whatever field carries their identifier.

## Testing:
Tested manually in lab. Saw matching files to main generated from a pass (****_arm_realtime_trajectory.json)