### PR TITLE
[RSDK-14385] Emit per-joint velocity and acceleration limits

### DIFF
--- a/src/viam/ur/module/test.cpp
+++ b/src/viam/ur/module/test.cpp
@@ -1274,11 +1274,12 @@ BOOST_AUTO_TEST_CASE(test_apply_calibration_preserves_world_geometry_centers_at_
 }
 
 BOOST_AUTO_TEST_CASE(test_to_sva_json_round_trips_via_parse) {
-    // parse -> apply_calibration(nominal) -> to_sva_json -> re-parse
-    // should give back world-frame geometry positions that still match the
-    // spec. Exercises the writer (translation/orientation/geometry
-    // emission) and the parser's quaternion code path on the writer's
-    // output.
+    // parse -> apply_calibration(nominal) -> with_kinematic_limits ->
+    // to_sva_json -> re-parse should give back world-frame geometry positions
+    // that still match the spec, and the stamped velocity and acceleration
+    // limits in degrees. Exercises the writer (translation/orientation/
+    // geometry/limit emission) and the parser's quaternion code path on the
+    // writer's output.
     const UrArmModel::Kinematics tbl = load("ur20");
 
     DHParams dh{};
@@ -1287,7 +1288,14 @@ BOOST_AUTO_TEST_CASE(test_to_sva_json_round_trips_via_parse) {
     dh.alpha = {std::numbers::pi / 2.0, 0.0, 0.0, std::numbers::pi / 2.0, -std::numbers::pi / 2.0, 0.0};
     dh.theta = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-    const std::string json_str = tbl.apply_calibration(dh).to_sva_json();
+    // Distinct per joint, so a fanned-out or transposed write fails here
+    // rather than passing on six equal values.
+    const vector6d_t velocity_degs = {110.0, 120.0, 130.0, 140.0, 150.0, 160.0};
+    const vector6d_t acceleration_degs = {210.0, 220.0, 230.0, 240.0, 250.0, 260.0};
+
+    const std::string json_str = tbl.apply_calibration(dh)
+                                     .with_kinematic_limits(degrees_to_radians(velocity_degs), degrees_to_radians(acceleration_degs))
+                                     .to_sva_json();
     const auto tmp = std::filesystem::temp_directory_path() / "ur20_round_trip.json";
     {
         std::ofstream out(tmp);
@@ -1309,6 +1317,77 @@ BOOST_AUTO_TEST_CASE(test_to_sva_json_round_trips_via_parse) {
         BOOST_CHECK_SMALL(world.x() - expect[0], 1e-3);
         BOOST_CHECK_SMALL(world.y() - expect[1], 1e-3);
         BOOST_CHECK_SMALL(world.z() - expect[2], 1e-3);
+    }
+
+    // The stamping input is radians and the schema is degrees, so this also
+    // covers the conversion.
+    for (std::size_t i = 0; i < 6; ++i) {
+        BOOST_REQUIRE(reparsed.limits[i].max_velocity_deg_per_sec.has_value());
+        BOOST_REQUIRE(reparsed.limits[i].max_acceleration_deg_per_sec2.has_value());
+        BOOST_CHECK_CLOSE(*reparsed.limits[i].max_velocity_deg_per_sec, velocity_degs[i], 1e-9);
+        BOOST_CHECK_CLOSE(*reparsed.limits[i].max_acceleration_deg_per_sec2, acceleration_degs[i], 1e-9);
+    }
+
+    // Position bounds must survive the added fields untouched.
+    for (std::size_t i = 0; i < 6; ++i) {
+        BOOST_CHECK_EQUAL(reparsed.limits[i].min_deg, (i == 2) ? -180.0 : -360.0);
+        BOOST_CHECK_EQUAL(reparsed.limits[i].max_deg, (i == 2) ? 180.0 : 360.0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_configured_zero_limits_are_published_as_zero) {
+    // `speed_degs_per_sec` validation rejects an all-zero array but accepts a single zero element,
+    // and zero is a real limit of zero on the wire rather than a way of saying unbounded. So a
+    // configured zero has to be emitted, not dropped: dropping it would describe an axis that
+    // cannot move as having no bound at all.
+    const vector6d_t velocity_degs = {110.0, 0.0, 130.0, 140.0, 150.0, 160.0};
+    const vector6d_t acceleration_degs = {210.0, 220.0, 0.0, 240.0, 250.0, 260.0};
+
+    const auto stamped = load("ur20").with_kinematic_limits(degrees_to_radians(velocity_degs), degrees_to_radians(acceleration_degs));
+
+    BOOST_REQUIRE(stamped.limits[1].max_velocity_deg_per_sec.has_value());
+    BOOST_CHECK_EQUAL(*stamped.limits[1].max_velocity_deg_per_sec, 0.0);
+    BOOST_REQUIRE(stamped.limits[2].max_acceleration_deg_per_sec2.has_value());
+    BOOST_CHECK_EQUAL(*stamped.limits[2].max_acceleration_deg_per_sec2, 0.0);
+
+    // The other axis of the same joint is untouched.
+    BOOST_REQUIRE(stamped.limits[1].max_acceleration_deg_per_sec2.has_value());
+    BOOST_CHECK_CLOSE(*stamped.limits[1].max_acceleration_deg_per_sec2, 220.0, 1e-9);
+
+    // And the key is present in the document with an explicit 0, not missing.
+    Json::Value root;
+    std::istringstream in{stamped.to_sva_json()};
+    const Json::CharReaderBuilder reader_builder;
+    std::string errs;
+    BOOST_REQUIRE(Json::parseFromStream(reader_builder, in, &root, &errs));
+    BOOST_REQUIRE(root["joints"][1].isMember("max_velocity"));
+    BOOST_CHECK_EQUAL(root["joints"][1]["max_velocity"].asDouble(), 0.0);
+    BOOST_REQUIRE(root["joints"][2].isMember("max_acceleration"));
+    BOOST_CHECK_EQUAL(root["joints"][2]["max_acceleration"].asDouble(), 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(test_unstamped_kinematic_limits_are_omitted) {
+    // The shipped files carry position bounds only, and an omitted field is
+    // how the schema spells unbounded, so an unstamped document must leave
+    // the fields out rather than write a placeholder value that a consumer
+    // would read as a real limit.
+    const auto tbl = load("ur20");
+    for (std::size_t i = 0; i < 6; ++i) {
+        BOOST_CHECK(!tbl.limits[i].max_velocity_deg_per_sec.has_value());
+        BOOST_CHECK(!tbl.limits[i].max_acceleration_deg_per_sec2.has_value());
+    }
+
+    Json::Value root;
+    std::istringstream in{tbl.to_sva_json()};
+    const Json::CharReaderBuilder reader_builder;
+    std::string errs;
+    BOOST_REQUIRE(Json::parseFromStream(reader_builder, in, &root, &errs));
+
+    BOOST_REQUIRE(root["joints"].isArray());
+    BOOST_REQUIRE_EQUAL(root["joints"].size(), 6U);
+    for (const auto& joint : root["joints"]) {
+        BOOST_CHECK(!joint.isMember("max_velocity"));
+        BOOST_CHECK(!joint.isMember("max_acceleration"));
     }
 }
 

--- a/src/viam/ur/module/ur_arm_model.cpp
+++ b/src/viam/ur/module/ur_arm_model.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <initializer_list>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -253,7 +254,22 @@ JointLimits parse_joint_limits(const std::filesystem::path& path, const Json::Va
     if (!joint.isMember("max") || !joint["max"].isNumeric()) {
         throw_parse_error(path, "joint missing numeric `max`");
     }
-    return JointLimits{joint["min"].asDouble(), joint["max"].asDouble()};
+
+    // `max_velocity` and `max_acceleration` are optional in the schema, so an
+    // absent field is not an error, but a present one that is not a number is.
+    // We read them so a document we emitted parses back to what we wrote.
+    const auto optional_limit = [&](const char* field) -> std::optional<double> {
+        if (!joint.isMember(field)) {
+            return std::nullopt;
+        }
+        if (!joint[field].isNumeric()) {
+            throw_parse_error(path, std::string{"joint `"} + field + "` is present but not a number");
+        }
+        return joint[field].asDouble();
+    };
+
+    return JointLimits{
+        joint["min"].asDouble(), joint["max"].asDouble(), optional_limit("max_velocity"), optional_limit("max_acceleration")};
 }
 
 Json::Value translation_json(const Eigen::Vector3d& t) {
@@ -396,6 +412,19 @@ UrArmModel::Kinematics UrArmModel::Kinematics::apply_calibration(const DHParams&
     }
 
     out.link_locals = new_link_locals;
+    return out;
+}
+
+UrArmModel::Kinematics UrArmModel::Kinematics::with_kinematic_limits(const urcl::vector6d_t& velocity_rad_per_sec,
+                                                                     const urcl::vector6d_t& acceleration_rad_per_sec2) const {
+    // We publish whatever is configured, zero included. Only an absent field means unbounded, so a
+    // configured zero has to go out as zero: our validation accepts an array with a single zero
+    // element, and omitting it would tell the planner that an axis which cannot move is unbounded.
+    Kinematics out = *this;
+    for (std::size_t i = 0; i < k_num_dh_joints; ++i) {
+        out.limits[i].max_velocity_deg_per_sec = radians_to_degrees(velocity_rad_per_sec[i]);
+        out.limits[i].max_acceleration_deg_per_sec2 = radians_to_degrees(acceleration_rad_per_sec2[i]);
+    }
     return out;
 }
 
@@ -566,6 +595,14 @@ std::string UrArmModel::Kinematics::to_sva_json() const {
             joint["axis"] = dh_z_axis;
             joint["min"] = limits[i - 1].min_deg;
             joint["max"] = limits[i - 1].max_deg;
+            // Leaving these out is how the schema spells "unbounded", so we
+            // emit nothing rather than a placeholder when we have no value.
+            if (limits[i - 1].max_velocity_deg_per_sec) {
+                joint["max_velocity"] = *limits[i - 1].max_velocity_deg_per_sec;
+            }
+            if (limits[i - 1].max_acceleration_deg_per_sec2) {
+                joint["max_acceleration"] = *limits[i - 1].max_acceleration_deg_per_sec2;
+            }
             joints.append(joint);
         }
 

--- a/src/viam/ur/module/ur_arm_model.hpp
+++ b/src/viam/ur/module/ur_arm_model.hpp
@@ -43,11 +43,18 @@ struct DHParams {
     urcl::vector6d_t theta;
 };
 
-// Joint angular limits, in degrees, matching the `min`/`max` fields in
-// shipped `kinematics/<model>.json` files.
+// Joint limits, in degrees, matching the `min`/`max`/`max_velocity`/
+// `max_acceleration` fields in shipped `kinematics/<model>.json` files.
+//
+// The two kinematic limits are optional because the SVA schema treats an
+// omitted field as unbounded, and because the shipped files carry position
+// bounds only. They are filled in per arm instance from configured speed and
+// acceleration by `Kinematics::with_kinematic_limits`.
 struct JointLimits {
     double min_deg;
     double max_deg;
+    std::optional<double> max_velocity_deg_per_sec;
+    std::optional<double> max_acceleration_deg_per_sec2;
 };
 
 // A geometry expressed in its link's parent (joint) frame.
@@ -124,6 +131,11 @@ class UrArmModel::Kinematics {
     std::array<std::string, 7> link_names;
 
     Kinematics apply_calibration(const DHParams& dh) const;
+
+    // Returns a copy carrying the given per-joint velocity and acceleration
+    // limits. Inputs are radians, matching what `URArm::state_` holds; the
+    // conversion to the degrees the SVA schema uses happens here.
+    Kinematics with_kinematic_limits(const urcl::vector6d_t& velocity_rad_per_sec, const urcl::vector6d_t& acceleration_rad_per_sec2) const;
 
     // Serialize this kinematics to an RDK-compatible SVA kinematics JSON.
     std::string to_sva_json() const;

--- a/src/viam/ur/module/ur_arm_state.cpp
+++ b/src/viam/ur/module/ur_arm_state.cpp
@@ -209,8 +209,11 @@ std::unique_ptr<URArm::state_> URArm::state_::create(UrArmModel configured_model
                                           traceid_metadata_key,
                                           ports);
 
-    state->set_velocity_limits(parse_and_validate_joint_limits(config, "speed_degs_per_sec"));
-    state->set_acceleration_limits(parse_and_validate_joint_limits(config, "acceleration_degs_per_sec2"));
+    // The setters return what they actually stored, which is the configured value clamped against
+    // any ceiling, so we keep that as the configured limits the kinematics document publishes.
+    state->configured_velocity_limits_ = state->set_velocity_limits(parse_and_validate_joint_limits(config, "speed_degs_per_sec"));
+    state->configured_acceleration_limits_ =
+        state->set_acceleration_limits(parse_and_validate_joint_limits(config, "acceleration_degs_per_sec2"));
 
     // Hold the mutex while we start the worker thread. It will not be
     // able to advance, but will be ready to take over work as soon as
@@ -958,6 +961,7 @@ std::string URArm::state_::get_dh_kinematics_json(std::chrono::steady_clock::dur
     std::call_once(*payload.json_once, [&] {
         payload.json = payload.arm_model.load_kinematics((resource_root_ / "kinematics" / payload.arm_model.sdk_name()).concat(".json"))
                            .apply_calibration({payload.info.dh_a_, payload.info.dh_d_, payload.info.dh_alpha_, payload.info.dh_theta_})
+                           .with_kinematic_limits(configured_velocity_limits_, configured_acceleration_limits_)
                            .to_sva_json();
     });
     return payload.json;

--- a/src/viam/ur/module/ur_arm_state.hpp
+++ b/src/viam/ur/module/ur_arm_state.hpp
@@ -266,9 +266,17 @@ class URArm::state_ {
     //
     // `mutable` is intentional on `json_once`/`json`: the shared state is
     // accessed via `shared_future<T>::get()` returning `const T&`, and the
-    // JSON is a deterministic function of `info` and `arm_model`. Every
-    // caller observes the same logical value; `std::call_once` synchronizes
-    // the first JSON-wanting caller's build with later reuses.
+    // JSON is a deterministic function of this payload's `info` and
+    // `arm_model` plus the configured limits, which do not change while the
+    // payload lives. Every caller observes the same logical value;
+    // `std::call_once` synchronizes the first JSON-wanting caller's build
+    // with later reuses.
+    //
+    // Note the calibration is per connection, not per `state_`: each new
+    // connection period installs a fresh payload (see
+    // `state_connected_::recv_arm_data`), which is why the once_flag belongs
+    // here rather than on `state_`. Hoisting the cache up to `state_` would
+    // keep serving the previous connection's calibration after a reconnect.
     //
     // `json_once` is held via `unique_ptr` because `std::once_flag` is
     // neither copyable nor movable, and the payload must be at least
@@ -593,6 +601,23 @@ class URArm::state_ {
 
     vector6d_t velocity_limits_{};
     vector6d_t acceleration_limits_{};
+
+    // The configured limits, already clamped against any ceiling, captured once during `create`
+    // and never touched again. The kinematics document describes how this arm is configured, so it
+    // publishes these rather than the live `velocity_limits_`.
+    //
+    // That is a deliberate tradeoff, not just a convenience. `set_speed_degs_per_sec` via DoCommand
+    // moves the live limits for the rest of the session, and moves plan against those, so after
+    // such a call the document reports a speed the arm will not use. We accept that because the
+    // framesystem reads kinematics once when it builds the resource graph and never re-reads it, so
+    // publishing live values would not reach the planner anyway; it would only make the two RDK
+    // read paths disagree with each other and make the bytes change under anything hashing them.
+    // Publishing the configured value also matches the yaskawa module, which gives the motion
+    // service the same meaning from both arms.
+    //
+    // Written before the worker thread starts, so no lock is needed to read them.
+    vector6d_t configured_velocity_limits_{};
+    vector6d_t configured_acceleration_limits_{};
 
     const double path_tolerance_delta_rads_;
     const std::optional<double> path_colinearization_ratio_;


### PR DESCRIPTION
Ticket 7 of [RSDK-14385](https://viam.atlassian.net/browse/RSDK-14385). The SVA kinematics schema now carries optional per-joint `max_velocity` and `max_acceleration` so the motion service can generate trajectories itself instead of handing arms a path and asking them to build a kinematic chain. This publishes them from our synthesized document.

## What changed

- `JointLimits` gains `max_velocity_deg_per_sec` and `max_acceleration_deg_per_sec2` as `std::optional`, because an absent field is how the schema spells unbounded and the shipped `kinematics/<model>.json` files carry position bounds only.
- `Kinematics::with_kinematic_limits` attaches per-joint limits, taking radians (what `state_` holds) and converting to the degrees the schema uses.
- `to_sva_json` writes each field only when set. `load_kinematics` reads them back, so a document we emit reparses to what we wrote.
- `state_::create` captures the configured limits once, and `get_dh_kinematics_json` stamps them inside the existing `call_once`.

## What we publish, and one deliberate tradeoff

The values are the configured `speed_degs_per_sec` and `acceleration_degs_per_sec2`, already clamped against any `max_speed_degs_per_sec` / `max_acceleration_degs_per_sec2` ceiling, so what we advertise is what an un-overridden move will use. The ceilings are never the effective value: `clamp_velocity_limits` applies them on the way in, so a configured 30 under a ceiling of 100 runs at 30, and publishing 100 would be a looser bound than the arm honors.

We snapshot at configure time rather than reading the live limits. **`set_speed_degs_per_sec` via DoCommand therefore does not change what `GetKinematics` reports.** That is intentional, not an oversight:

- The framesystem reads kinematics once when it builds the resource graph and never re-reads it, so live values would not reach the planner anyway.
- Publishing live values would only make RDK's two read paths disagree with each other, since `armplanning.MoveArm` fetches per call while the framesystem does not.
- It would also make the returned bytes change under anything hashing them.
- Publishing the configured value matches the yaskawa module, so the motion service gets the same meaning from both arms.

A consequence worth knowing: after `DoCommand{"set_speed_degs_per_sec": 5}` on an arm configured at 60, the document still reports 60 while MoveThrough/ToJointPositions plan against 5.

## Testing

- `test_to_sva_json_round_trips_via_parse` extended to stamp per-joint-distinct limits (110-160 deg/s, 210-260 deg/s²) so a transposed or broadcast write fails, and to check position bounds survive.
- `test_configured_zero_limits_are_published_as_zero` pins the zero behavior in both the parsed optionals and the emitted JSON.
- `test_unstamped_kinematic_limits_are_omitted` checks an unstamped document has neither key.

`make test` green, `-Wall -Werror` clean, clang-tidy and clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSDK-14385]: https://viam.atlassian.net/browse/RSDK-14385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ